### PR TITLE
add Continuation listener parameter  to migrators.migrate() method an…

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemProvider.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemProvider.java
@@ -13,6 +13,7 @@ import org.cryptomator.cryptofs.common.Constants;
 import org.cryptomator.cryptofs.common.FileSystemCapabilityChecker;
 import org.cryptomator.cryptofs.common.MasterkeyBackupFileHasher;
 import org.cryptomator.cryptofs.migration.Migrators;
+import org.cryptomator.cryptofs.migration.api.MigrationContinuationListener;
 import org.cryptomator.cryptolib.Cryptors;
 import org.cryptomator.cryptolib.api.Cryptor;
 import org.cryptomator.cryptolib.api.CryptorProvider;
@@ -304,7 +305,7 @@ public class CryptoFileSystemProvider extends FileSystemProvider {
 	private void migrateFileSystemIfRequired(CryptoFileSystemUri parsedUri, CryptoFileSystemProperties properties) throws IOException, FileSystemNeedsMigrationException {
 		if (Migrators.get().needsMigration(parsedUri.pathToVault(), properties.masterkeyFilename())) {
 			if (properties.migrateImplicitly()) {
-				Migrators.get().migrate(parsedUri.pathToVault(), properties.masterkeyFilename(), properties.passphrase(), (state, progress) -> {});
+				Migrators.get().migrate(parsedUri.pathToVault(), properties.masterkeyFilename(), properties.passphrase(), (state, progress) -> {}, event -> MigrationContinuationListener.ContinuationResult.PROCEED);
 			} else {
 				throw new FileSystemNeedsMigrationException(parsedUri.pathToVault());
 			}

--- a/src/main/java/org/cryptomator/cryptofs/migration/Migrators.java
+++ b/src/main/java/org/cryptomator/cryptofs/migration/Migrators.java
@@ -17,6 +17,7 @@ import javax.inject.Inject;
 
 import org.cryptomator.cryptofs.common.Constants;
 import org.cryptomator.cryptofs.common.FileSystemCapabilityChecker;
+import org.cryptomator.cryptofs.migration.api.MigrationContinuationListener;
 import org.cryptomator.cryptofs.migration.api.MigrationProgressListener;
 import org.cryptomator.cryptofs.migration.api.Migrator;
 import org.cryptomator.cryptofs.migration.api.NoApplicableMigratorException;
@@ -33,7 +34,7 @@ import org.cryptomator.cryptolib.api.UnsupportedVaultFormatException;
  * <pre>
  * <code>
  * if (Migrators.get().{@link #needsMigration(Path, String) needsMigration(pathToVault, masterkeyFileName)}) {
- * 	Migrators.get().{@link #migrate(Path, String, CharSequence, MigrationProgressListener) migrate(pathToVault, masterkeyFileName, passphrase, migrationProgressListener)};
+ * 	Migrators.get().{@link #migrate(Path, String, CharSequence, MigrationProgressListener, MigrationContinuationListener) migrate(pathToVault, masterkeyFileName, passphrase, migrationProgressListener)};
  * }
  * </code>
  * </pre>
@@ -97,7 +98,7 @@ public class Migrators {
 	 * @throws FileSystemCapabilityChecker.MissingCapabilityException If the underlying filesystem lacks features required to store a vault
 	 * @throws IOException if an I/O error occurs migrating the vault
 	 */
-	public void migrate(Path pathToVault, String masterkeyFilename, CharSequence passphrase, MigrationProgressListener progressListener) throws NoApplicableMigratorException, InvalidPassphraseException, IOException {
+	public void migrate(Path pathToVault, String masterkeyFilename, CharSequence passphrase, MigrationProgressListener progressListener, MigrationContinuationListener continuationListener) throws NoApplicableMigratorException, InvalidPassphraseException, IOException {
 		fsCapabilityChecker.assertAllCapabilities(pathToVault);
 		
 		Path masterKeyPath = pathToVault.resolve(masterkeyFilename);
@@ -106,7 +107,7 @@ public class Migrators {
 
 		try {
 			Migrator migrator = findApplicableMigrator(keyFile.getVersion()).orElseThrow(NoApplicableMigratorException::new);
-			migrator.migrate(pathToVault, masterkeyFilename, passphrase, progressListener);
+			migrator.migrate(pathToVault, masterkeyFilename, passphrase, progressListener, continuationListener);
 		} catch (UnsupportedVaultFormatException e) {
 			// might be a tampered masterkey file, as this exception is also thrown if the vault version MAC is not authentic.
 			throw new IllegalStateException("Vault version checked beforehand but not supported by migrator.");

--- a/src/test/java/org/cryptomator/cryptofs/migration/MigratorsTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/migration/MigratorsTest.java
@@ -6,6 +6,7 @@
 package org.cryptomator.cryptofs.migration;
 
 import org.cryptomator.cryptofs.common.FileSystemCapabilityChecker;
+import org.cryptomator.cryptofs.migration.api.MigrationContinuationListener;
 import org.cryptomator.cryptofs.migration.api.MigrationProgressListener;
 import org.cryptomator.cryptofs.migration.api.Migrator;
 import org.cryptomator.cryptofs.migration.api.NoApplicableMigratorException;
@@ -80,7 +81,7 @@ public class MigratorsTest {
 	public void testMigrateWithoutMigrators() throws IOException {
 		Migrators migrators = new Migrators(Collections.emptyMap(), fsCapabilityChecker);
 		Assertions.assertThrows(NoApplicableMigratorException.class, () -> {
-			migrators.migrate(pathToVault, "masterkey.cryptomator", "secret", (state, progress) -> {});
+			migrators.migrate(pathToVault, "masterkey.cryptomator", "secret", (state, progress) -> {}, event -> MigrationContinuationListener.ContinuationResult.PROCEED);
 		});
 	}
 	
@@ -94,7 +95,7 @@ public class MigratorsTest {
 				put(Migration.ZERO_TO_ONE, migrator);
 			}
 		}, fsCapabilityChecker);
-		migrators.migrate(pathToVault, "masterkey.cryptomator", "secret", listener);
+		migrators.migrate(pathToVault, "masterkey.cryptomator", "secret", listener, event -> MigrationContinuationListener.ContinuationResult.PROCEED);
 		Mockito.verify(migrator).migrate(pathToVault, "masterkey.cryptomator", "secret", listener);
 	}
 
@@ -109,7 +110,7 @@ public class MigratorsTest {
 		}, fsCapabilityChecker);
 		Mockito.doThrow(new UnsupportedVaultFormatException(Integer.MAX_VALUE, 1)).when(migrator).migrate(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
 		Assertions.assertThrows(IllegalStateException.class, () -> {
-			migrators.migrate(pathToVault, "masterkey.cryptomator", "secret", (state, progress) -> {});
+			migrators.migrate(pathToVault, "masterkey.cryptomator", "secret", (state, progress) -> {}, event -> MigrationContinuationListener.ContinuationResult.PROCEED);
 		});
 	}
 


### PR DESCRIPTION
…d update test

Some test are still failing:
```
[ERROR] Failures: 
[ERROR]   MigratorsTest.testMigrate:99 
Argument(s) are different! Wanted:
migrator.migrate(
    Mock for Path, hashCode: 800040885,
    "masterkey.cryptomator",
    "secret",
    Mock for MigrationProgressListener, hashCode: 1663786105
);
-> at org.cryptomator.cryptofs.migration.MigratorsTest.testMigrate(MigratorsTest.java:99)
Actual invocations have different arguments:
migrator.migrate(
    Mock for Path, hashCode: 800040885,
    "masterkey.cryptomator",
    "secret",
    Mock for MigrationProgressListener, hashCode: 1663786105,
    org.cryptomator.cryptofs.migration.MigratorsTest$$Lambda$836/0x00000008004b5440@6a552721
);
-> at org.cryptomator.cryptofs.migration.Migrators.migrate(Migrators.java:110)
[ERROR]   MigratorsTest.testMigrateUnsupportedVaultFormat:112 Expected java.lang.IllegalStateException to be thrown, but nothing was thrown.
```