### PR TITLE
Feature/#103 refactor contains vault

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemProvider.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemProvider.java
@@ -172,7 +172,7 @@ public class CryptoFileSystemProvider extends FileSystemProvider {
 	 */
 	public static boolean containsVault(Path pathToAssumedVault, String vaultConfigFilename, String masterkeyFilename) {
 		try {
-			return checkDirStructure(pathToAssumedVault, vaultConfigFilename, masterkeyFilename) == DirStructure.VAULT;
+			return checkDirStructureForVault(pathToAssumedVault, vaultConfigFilename, masterkeyFilename) == DirStructure.VAULT;
 		} catch (IOException e) {
 			return false;
 		}
@@ -188,7 +188,7 @@ public class CryptoFileSystemProvider extends FileSystemProvider {
 	 * @throws IOException
 	 * @since 2.0.0
 	 */
-	public static DirStructure checkDirStructure(Path pathToAssumedVault, String vaultConfigFilename, String masterkeyFilename) throws IOException {
+	public static DirStructure checkDirStructureForVault(Path pathToAssumedVault, String vaultConfigFilename, String masterkeyFilename) throws IOException {
 		return DirStructure.checkDirStructure(pathToAssumedVault, vaultConfigFilename, masterkeyFilename);
 	}
 

--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemProvider.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemProvider.java
@@ -161,18 +161,35 @@ public class CryptoFileSystemProvider extends FileSystemProvider {
 
 	/**
 	 * Checks if the folder represented by the given path exists and contains a valid vault structure.
+	 * <p>
+	 * See {@link DirStructure#VAULT} for the criterias of being a valid vault.
 	 *
-	 * @param pathToVault         A directory path
+	 * @param pathToAssumedVault A directory path
 	 * @param vaultConfigFilename Name of the vault config file
-	 * @param masterkeyFilename   Name of the masterkey file
+	 * @param masterkeyFilename Name of the masterkey file
 	 * @return <code>true</code> if the directory seems to contain a vault.
 	 * @since 2.0.0
 	 */
-	public static boolean containsVault(Path pathToVault, String vaultConfigFilename, String masterkeyFilename) {
-		Path vaultConfigPath = pathToVault.resolve(vaultConfigFilename);
-		Path masterkeyPath = pathToVault.resolve(masterkeyFilename);
-		Path dataDirPath = pathToVault.resolve(Constants.DATA_DIR_NAME);
-		return (Files.isReadable(vaultConfigPath) || Files.isReadable(masterkeyPath)) && Files.isDirectory(dataDirPath);
+	public static boolean containsVault(Path pathToAssumedVault, String vaultConfigFilename, String masterkeyFilename) {
+		try {
+			return checkDirStructure(pathToAssumedVault, vaultConfigFilename, masterkeyFilename) == DirStructure.VAULT;
+		} catch (IOException e) {
+			return false;
+		}
+	}
+
+	/**
+	 * Convenience method for {@link DirStructure#checkDirStructure(Path, String, String)}.
+	 *
+	 * @param pathToAssumedVault
+	 * @param vaultConfigFilename
+	 * @param masterkeyFilename
+	 * @return a {@link DirStructure} object
+	 * @throws IOException
+	 * @since 2.0.0
+	 */
+	public static DirStructure checkDirStructure(Path pathToAssumedVault, String vaultConfigFilename, String masterkeyFilename) throws IOException {
+		return DirStructure.checkDirStructure(pathToAssumedVault, vaultConfigFilename, masterkeyFilename);
 	}
 
 	/**

--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemProvider.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemProvider.java
@@ -156,26 +156,7 @@ public class CryptoFileSystemProvider extends FileSystemProvider {
 		} finally {
 			Arrays.fill(rawKey, (byte) 0x00);
 		}
-		assert containsVault(pathToVault, properties.vaultConfigFilename(), properties.masterkeyFilename());
-	}
-
-	/**
-	 * Checks if the folder represented by the given path exists and contains a valid vault structure.
-	 * <p>
-	 * See {@link DirStructure#VAULT} for the criteria of being a valid vault.
-	 *
-	 * @param pathToAssumedVault A directory path
-	 * @param vaultConfigFilename Name of the vault config file
-	 * @param masterkeyFilename Name of the masterkey file
-	 * @return <code>true</code> if the directory seems to contain a vault.
-	 * @since 2.0.0
-	 */
-	public static boolean containsVault(Path pathToAssumedVault, String vaultConfigFilename, String masterkeyFilename) {
-		try {
-			return checkDirStructureForVault(pathToAssumedVault, vaultConfigFilename, masterkeyFilename) == DirStructure.VAULT;
-		} catch (IOException e) {
-			return false;
-		}
+		assert checkDirStructureForVault(pathToVault, properties.vaultConfigFilename(), properties.masterkeyFilename()) == DirStructure.VAULT;
 	}
 
 	/**

--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemProvider.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemProvider.java
@@ -162,7 +162,7 @@ public class CryptoFileSystemProvider extends FileSystemProvider {
 	/**
 	 * Checks if the folder represented by the given path exists and contains a valid vault structure.
 	 * <p>
-	 * See {@link DirStructure#VAULT} for the criterias of being a valid vault.
+	 * See {@link DirStructure#VAULT} for the criteria of being a valid vault.
 	 *
 	 * @param pathToAssumedVault A directory path
 	 * @param vaultConfigFilename Name of the vault config file
@@ -179,7 +179,7 @@ public class CryptoFileSystemProvider extends FileSystemProvider {
 	}
 
 	/**
-	 * Convenience method for {@link DirStructure#checkDirStructure(Path, String, String)}.
+	 * Delegate to {@link DirStructure#checkDirStructure(Path, String, String)}.
 	 *
 	 * @param pathToAssumedVault
 	 * @param vaultConfigFilename

--- a/src/main/java/org/cryptomator/cryptofs/DirStructure.java
+++ b/src/main/java/org/cryptomator/cryptofs/DirStructure.java
@@ -12,10 +12,10 @@ import java.nio.file.attribute.BasicFileAttributes;
  * Enumeration of the vault directory structure resemblances.
  * <p>
  * A valid vault must contain a `d` directory.
- * If the vault version is 8, it must also contains a vault config file.
- * If the vault version is smaller than 8, it must also contain a masterkey file.
+ * Beginning with vault format 8, it must also contain a vault config file.
+ * If the vault format is lower than 8, it must instead contain a masterkey file.
  * <p>
- * In the latter case, to distinct between a damaged vault 8 directory and a legacy vault the masterkey file must be read.
+ * In the latter case, to distinguish between a damaged vault 8 directory and a legacy vault the masterkey file must be read.
  * For efficiency reasons, this class only checks for existence/readability of the above elements.
  * Hence, if the result of {@link #checkDirStructure(Path, String, String)} is {@link #MAYBE_LEGACY}, one needs to parse
  * the masterkey file and read out the vault version to determine this case.

--- a/src/main/java/org/cryptomator/cryptofs/DirStructure.java
+++ b/src/main/java/org/cryptomator/cryptofs/DirStructure.java
@@ -1,0 +1,64 @@
+package org.cryptomator.cryptofs;
+
+import org.cryptomator.cryptofs.common.Constants;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Enumeration of the vault directory structure resemblances.
+ * <p>
+ * A valid vault must contain a `d` directory.
+ * If the vault version is 8, it must also contains a vault config file.
+ * If the vault version is smaller than 8, it must also contain a masterkey file.
+ * <p>
+ * In the latter case, to distinct between a damaged vault 8 directory and a legacy vault the masterkey file must be read.
+ * For efficiency reasons, this class only checks for existence/readability of the above elements.
+ * Hence, if the result of {@link #checkDirStructure(Path, String, String)} is {@link #MAYBE_LEGACY}, one needs to parse
+ * the masterkey file and read out the vault version to determine this case.
+ *
+ * @since 2.0.0
+ */
+public enum DirStructure {
+
+	/**
+	 * Dir contains a <code>d</code> dir as well as a vault config file.
+	 */
+	VAULT,
+
+	/**
+	 * Dir contains a <code>d</code> dir and a masterkey file, but misses a vault config file.
+	 * Either needs migration to a newer format or damaged.
+	 */
+	MAYBE_LEGACY,
+
+	/**
+	 * Dir does not qualify as vault.
+	 */
+	UNRELATED;
+
+
+	/**
+	 * Analyzes the structure of the given directory under certain vault existence criteria.
+	 *
+	 * @param pathToVault A directory path
+	 * @param vaultConfigFilename Name of the vault config file
+	 * @param masterkeyFilename Name of the masterkey file
+	 * @return enum indicating what this directory might be
+	 * @throws IOException if the directory itself or certain components cannot be accessed/read.
+	 */
+	public static DirStructure checkDirStructure(Path pathToVault, String vaultConfigFilename, String masterkeyFilename) throws IOException {
+		Path vaultConfigPath = pathToVault.resolve(vaultConfigFilename);
+		Path masterkeyPath = pathToVault.resolve(masterkeyFilename);
+		Path dataDirPath = pathToVault.resolve(Constants.DATA_DIR_NAME);
+		if (Files.isDirectory(dataDirPath)) {
+			if (Files.isReadable(vaultConfigPath)) {
+				return VAULT;
+			} else if (Files.isReadable(masterkeyPath)) {
+				return MAYBE_LEGACY;
+			}
+		}
+		return UNRELATED;
+	}
+}

--- a/src/main/java/org/cryptomator/cryptofs/DirStructure.java
+++ b/src/main/java/org/cryptomator/cryptofs/DirStructure.java
@@ -4,7 +4,9 @@ import org.cryptomator.cryptofs.common.Constants;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.NotDirectoryException;
 import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
 
 /**
  * Enumeration of the vault directory structure resemblances.
@@ -46,9 +48,12 @@ public enum DirStructure {
 	 * @param vaultConfigFilename Name of the vault config file
 	 * @param masterkeyFilename Name of the masterkey file
 	 * @return enum indicating what this directory might be
-	 * @throws IOException if the directory itself or certain components cannot be accessed/read.
+	 * @throws IOException if the provided path is not a directory, does not exist or cannot be read
 	 */
 	public static DirStructure checkDirStructure(Path pathToVault, String vaultConfigFilename, String masterkeyFilename) throws IOException {
+		if(! Files.readAttributes(pathToVault, BasicFileAttributes.class).isDirectory()) {
+			throw new NotDirectoryException(pathToVault.toString());
+		}
 		Path vaultConfigPath = pathToVault.resolve(vaultConfigFilename);
 		Path masterkeyPath = pathToVault.resolve(masterkeyFilename);
 		Path dataDirPath = pathToVault.resolve(Constants.DATA_DIR_NAME);

--- a/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemProviderIntegrationTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemProviderIntegrationTest.java
@@ -227,9 +227,9 @@ public class CryptoFileSystemProviderIntegrationTest {
 		@Test
 		@Order(2)
 		@DisplayName("get filesystem with incorrect credentials")
-		public void testGetFsWithWrongCredentials() {
-			Assumptions.assumeTrue(CryptoFileSystemProvider.containsVault(pathToVault1, "vault.cryptomator", "masterkey.cryptomator"));
-			Assumptions.assumeTrue(CryptoFileSystemProvider.containsVault(pathToVault2, "vault.cryptomator", "masterkey.cryptomator"));
+		public void testGetFsWithWrongCredentials() throws IOException {
+			Assumptions.assumeTrue(CryptoFileSystemProvider.checkDirStructureForVault(pathToVault1, "vault.cryptomator", "masterkey.cryptomator") == DirStructure.VAULT);
+			Assumptions.assumeTrue(CryptoFileSystemProvider.checkDirStructureForVault(pathToVault2, "vault.cryptomator", "masterkey.cryptomator") == DirStructure.VAULT);
 			Assertions.assertAll(
 					() -> {
 						URI fsUri = CryptoFileSystemUri.create(pathToVault1);

--- a/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemProviderTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemProviderTest.java
@@ -46,7 +46,6 @@ import static java.nio.file.Paths.get;
 import static java.nio.file.StandardOpenOption.APPEND;
 import static java.util.Arrays.asList;
 import static org.cryptomator.cryptofs.CryptoFileSystemProperties.cryptoFileSystemProperties;
-import static org.cryptomator.cryptofs.CryptoFileSystemProvider.containsVault;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.mock;
@@ -209,69 +208,6 @@ public class CryptoFileSystemProviderTest {
 		inTest.newFileSystem(uri, properties);
 
 		Mockito.verify(fileSystems).create(Mockito.same(inTest), Mockito.eq(pathToVault.toAbsolutePath()), Mockito.eq(properties));
-	}
-
-	@Test
-	public void testContainsVaultReturnsTrueIfDirectoryContainsVaultConfigFileAndDataDir() throws IOException {
-		FileSystem fs = Jimfs.newFileSystem(Configuration.unix());
-
-		String vaultConfigFilename = "vaultconfig.foo.baz";
-		String masterkeyFilename = "masterkey.foo.baz";
-		Path pathToVault = fs.getPath("/vaultDir");
-
-		Path vaultConfigFile = pathToVault.resolve(vaultConfigFilename);
-		Path dataDir = pathToVault.resolve("d");
-		Files.createDirectories(dataDir);
-		Files.write(vaultConfigFile, new byte[0]);
-
-		Assertions.assertTrue(containsVault(pathToVault, vaultConfigFilename, masterkeyFilename));
-	}
-
-	@Test
-	public void testContainsVaultReturnsFalseIfDirectoryContainsMasterkeyFileAndDataDir() throws IOException {
-		FileSystem fs = Jimfs.newFileSystem(Configuration.unix());
-
-		String vaultConfigFilename = "vaultconfig.foo.baz";
-		String masterkeyFilename = "masterkey.foo.baz";
-		Path pathToVault = fs.getPath("/vaultDir");
-
-		Path masterkeyFile = pathToVault.resolve(masterkeyFilename);
-		Path dataDir = pathToVault.resolve("d");
-		Files.createDirectories(dataDir);
-		Files.write(masterkeyFile, new byte[0]);
-
-		Assertions.assertFalse(containsVault(pathToVault, vaultConfigFilename, masterkeyFilename));
-	}
-
-	@Test
-	public void testContainsVaultReturnsFalseIfDirectoryContainsOnlyDataDir() throws IOException {
-		FileSystem fs = Jimfs.newFileSystem(Configuration.unix());
-
-		String vaultConfigFilename = "vaultconfig.foo.baz";
-		String masterkeyFilename = "masterkey.foo.baz";
-		Path pathToVault = fs.getPath("/vaultDir");
-
-		Path dataDir = pathToVault.resolve("d");
-		Files.createDirectories(dataDir);
-
-		Assertions.assertFalse(containsVault(pathToVault, vaultConfigFilename, masterkeyFilename));
-	}
-
-	@Test
-	public void testContainsVaultReturnsFalseIfDirectoryContainsNoDataDir() throws IOException {
-		FileSystem fs = Jimfs.newFileSystem(Configuration.unix());
-
-		String vaultConfigFilename = "vaultconfig.foo.baz";
-		String masterkeyFilename = "masterkey.foo.baz";
-		Path pathToVault = fs.getPath("/vaultDir");
-
-		Path vaultConfigFile = pathToVault.resolve(vaultConfigFilename);
-		Path masterkeyFile = pathToVault.resolve(masterkeyFilename);
-		Files.createDirectories(pathToVault);
-		Files.write(vaultConfigFile, new byte[0]);
-		Files.write(masterkeyFile, new byte[0]);
-
-		Assertions.assertFalse(containsVault(pathToVault, vaultConfigFilename, masterkeyFilename));
 	}
 
 	@Test

--- a/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemProviderTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemProviderTest.java
@@ -228,7 +228,7 @@ public class CryptoFileSystemProviderTest {
 	}
 
 	@Test
-	public void testContainsVaultReturnsTrueIfDirectoryContainsMasterkeyFileAndDataDir() throws IOException {
+	public void testContainsVaultReturnsFalseIfDirectoryContainsMasterkeyFileAndDataDir() throws IOException {
 		FileSystem fs = Jimfs.newFileSystem(Configuration.unix());
 
 		String vaultConfigFilename = "vaultconfig.foo.baz";
@@ -240,7 +240,7 @@ public class CryptoFileSystemProviderTest {
 		Files.createDirectories(dataDir);
 		Files.write(masterkeyFile, new byte[0]);
 
-		Assertions.assertTrue(containsVault(pathToVault, vaultConfigFilename, masterkeyFilename));
+		Assertions.assertFalse(containsVault(pathToVault, vaultConfigFilename, masterkeyFilename));
 	}
 
 	@Test

--- a/src/test/java/org/cryptomator/cryptofs/DirStructureTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/DirStructureTest.java
@@ -1,0 +1,75 @@
+package org.cryptomator.cryptofs;
+
+import org.cryptomator.cryptofs.common.Constants;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+public class DirStructureTest {
+
+	private static final String KEY = "key";
+	private static final String CONFIG = "config";
+
+	@TempDir
+	Path vaultPath;
+
+	@Test
+	public void testNonExistingVaultPathThrowsIOException() {
+		Path vaultPath = Path.of("this/certainly/does/not/exist");
+		Assumptions.assumeTrue(Files.notExists(vaultPath));
+
+		Assertions.assertThrows(IOException.class, () -> DirStructure.checkDirStructure(vaultPath, CONFIG, KEY));
+	}
+
+	@Test
+	public void testNonDirectoryVaultPathThrowsIOException() throws IOException {
+		Path tmp = vaultPath.resolve("this");
+		Files.createFile(tmp);
+		Assumptions.assumeTrue(Files.exists(tmp));
+
+		Assertions.assertThrows(IOException.class, () -> DirStructure.checkDirStructure(tmp, CONFIG, KEY));
+	}
+
+	@ParameterizedTest(name = "Testing all combinations of data dir, config and masterkey file existence.")
+	@MethodSource("provideAllCases")
+	public void testAllCombosOfDataAndConfigAndKey(boolean createDataDir, boolean createConfig, boolean createKey, DirStructure expectedResult) throws IOException {
+		Path keyPath = vaultPath.resolve(KEY);
+		Path configPath = vaultPath.resolve(CONFIG);
+		Path dataDir = vaultPath.resolve(Constants.DATA_DIR_NAME);
+
+		if (createDataDir) {
+			Files.createDirectory(dataDir);
+		}
+		if (createConfig) {
+			Files.createFile(configPath);
+		}
+		if (createKey) {
+			Files.createFile(keyPath);
+		}
+
+		Assertions.assertEquals(expectedResult, DirStructure.checkDirStructure(vaultPath, CONFIG, KEY));
+	}
+
+	private static Stream<Arguments> provideAllCases() {
+		return Stream.of(
+				Arguments.of(true, true, true, DirStructure.VAULT),
+				Arguments.of(true, true, false, DirStructure.VAULT),
+				Arguments.of(true, false, true, DirStructure.MAYBE_LEGACY),
+				Arguments.of(true, false, false, DirStructure.UNRELATED),
+				Arguments.of(false, false, false, DirStructure.UNRELATED),
+				Arguments.of(false, false, true, DirStructure.UNRELATED),
+				Arguments.of(false, true, false, DirStructure.UNRELATED),
+				Arguments.of(false, true, true, DirStructure.UNRELATED)
+		);
+	}
+
+}


### PR DESCRIPTION
Closes #103 

As suggested, the (public) enum `DirStructure` is introduced with a static method to determine how "much" the directory structure resembles a vault.

I think the most important change is that the `containsVault(...)` method only checks for a vault structure of vault format 8. For a more fine grained result, use the method `CryptoFileSystemProvider.checkDirStructureForVault(...)`.