### PR TITLE
Extend HealthAPI to get more specific information about results

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/health/api/CommonDetailKeys.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/api/CommonDetailKeys.java
@@ -1,0 +1,11 @@
+package org.cryptomator.cryptofs.health.api;
+
+public class CommonDetailKeys {
+
+	public static final String ENCRYPTED_PATH = "Encrypted Path";
+	public static final String DIR_ID = "Directory ID";
+	public static final String DIR_ID_FILE = "Directory ID File";
+
+	private CommonDetailKeys() {};
+
+}

--- a/src/main/java/org/cryptomator/cryptofs/health/api/DiagnosticResult.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/api/DiagnosticResult.java
@@ -5,6 +5,7 @@ import org.cryptomator.cryptolib.api.Cryptor;
 import org.cryptomator.cryptolib.api.Masterkey;
 
 import java.nio.file.Path;
+import java.util.Map;
 
 public interface DiagnosticResult {
 
@@ -42,4 +43,12 @@ public interface DiagnosticResult {
 		throw new UnsupportedOperationException("Preliminary API not yet implemented");
 	}
 
+	/**
+	 * Get more specific info about the result like names of affected resources.
+	 *
+	 * @return A map of strings containing result specific information
+	 */
+	default Map<String, String> details() {
+		return Map.of();
+	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/DirIdCollision.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/DirIdCollision.java
@@ -3,6 +3,10 @@ package org.cryptomator.cryptofs.health.dirid;
 import org.cryptomator.cryptofs.health.api.DiagnosticResult;
 
 import java.nio.file.Path;
+import java.util.Map;
+
+import static org.cryptomator.cryptofs.health.api.CommonDetailKeys.DIR_ID;
+import static org.cryptomator.cryptofs.health.api.CommonDetailKeys.DIR_ID_FILE;
 
 /**
  * The directory id is used more than once.
@@ -27,5 +31,12 @@ public class DirIdCollision implements DiagnosticResult {
 	@Override
 	public String toString() {
 		return String.format("Directory ID reused: %s found in %s and %s", dirId, file, otherFile);
+	}
+
+	@Override
+	public Map<String, String> details() {
+		return Map.of(DIR_ID, dirId, //
+				DIR_ID_FILE, file.toString(), //
+				"Other " + DIR_ID_FILE, otherFile.toString());
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/HealthyDir.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/HealthyDir.java
@@ -3,6 +3,11 @@ package org.cryptomator.cryptofs.health.dirid;
 import org.cryptomator.cryptofs.health.api.DiagnosticResult;
 
 import java.nio.file.Path;
+import java.util.Map;
+
+import static org.cryptomator.cryptofs.health.api.CommonDetailKeys.DIR_ID;
+import static org.cryptomator.cryptofs.health.api.CommonDetailKeys.DIR_ID_FILE;
+import static org.cryptomator.cryptofs.health.api.CommonDetailKeys.ENCRYPTED_PATH;
 
 /**
  * Valid dir.c9r file, existing target dir
@@ -27,5 +32,12 @@ public class HealthyDir implements DiagnosticResult {
 	@Override
 	public String toString() {
 		return String.format("Good directory %s (%s) -> %s", dirIdFile, dirId, dir);
+	}
+
+	@Override
+	public Map<String, String> details() {
+		return Map.of(DIR_ID, dirId, //
+				DIR_ID_FILE, dirIdFile.toString(), //
+				ENCRYPTED_PATH, dir.toString());
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/MissingDirectory.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/MissingDirectory.java
@@ -3,12 +3,17 @@ package org.cryptomator.cryptofs.health.dirid;
 import org.cryptomator.cryptofs.health.api.DiagnosticResult;
 
 import java.nio.file.Path;
+import java.util.Map;
+
+import static org.cryptomator.cryptofs.health.api.CommonDetailKeys.DIR_ID;
+import static org.cryptomator.cryptofs.health.api.CommonDetailKeys.DIR_ID_FILE;
 
 /**
  * Valid dir.c9r file, nonexisting dir
  */
 public class MissingDirectory implements DiagnosticResult {
 
+	//TODO: maybe add not-existing dir path
 	final String dirId;
 	final Path file;
 
@@ -27,5 +32,10 @@ public class MissingDirectory implements DiagnosticResult {
 		return String.format("dir.c9r file (%s) points to non-existing directory.", file);
 	}
 
+	@Override
+	public Map<String, String> details() {
+		return Map.of(DIR_ID, dirId, //
+				DIR_ID_FILE, file.toString());
+	}
 	// fix: create dir?
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/ObeseDirFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/ObeseDirFile.java
@@ -4,6 +4,9 @@ import org.cryptomator.cryptofs.common.Constants;
 import org.cryptomator.cryptofs.health.api.DiagnosticResult;
 
 import java.nio.file.Path;
+import java.util.Map;
+
+import static org.cryptomator.cryptofs.health.api.CommonDetailKeys.DIR_ID_FILE;
 
 /**
  * The dir.c9r file's size is too large.
@@ -28,6 +31,11 @@ public class ObeseDirFile implements DiagnosticResult {
 		return String.format("Unexpected file size of %s: %d should be ≤ %d", dirFile, size, Constants.MAX_DIR_FILE_LENGTH);
 	}
 
+	@Override
+	public Map<String, String> details() {
+		return Map.of(DIR_ID_FILE, dirFile.toString(), //
+				"Size", Long.toString(size));
+	}
 	// potential fix: assign new dir id, move target dir
 
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
@@ -3,6 +3,9 @@ package org.cryptomator.cryptofs.health.dirid;
 import org.cryptomator.cryptofs.health.api.DiagnosticResult;
 
 import java.nio.file.Path;
+import java.util.Map;
+
+import static org.cryptomator.cryptofs.health.api.CommonDetailKeys.ENCRYPTED_PATH;
 
 /**
  * An orphan directory is a detached node, not referenced by any dir.c9r file.
@@ -23,6 +26,11 @@ public class OrphanDir implements DiagnosticResult {
 	@Override
 	public String toString() {
 		return String.format("Orphan directory: %s", dir);
+	}
+
+	@Override
+	public Map<String, String> details() {
+		return Map.of(ENCRYPTED_PATH, dir.toString());
 	}
 
 	// fix: create new dirId inside of L+F dir and rename existing dir accordingly.


### PR DESCRIPTION
The `DiagnosticResult` interface has a new method:
```Java
/**
 * Get more specific info about the result like names of affected resources.
 *
 * @return A map of strings containing result specific information
 */
default Map<String, String> details() {
	return Map.of();
}
```

For all already existing ResultImpl the method is overridden providing specific info.