### PR TITLE
Health-API: Implement OrphanDir.fix()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,10 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>3.0.0-M5</version>
+				<configuration>
+					<!-- Allow reflection for Mockito, so it can properly mock non-public classes -->
+					<argLine>--add-opens=org.cryptomator.cryptofs/org.cryptomator.cryptofs.health.dirid=ALL-UNNAMED</argLine>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/org/cryptomator/cryptofs/common/Constants.java
+++ b/src/main/java/org/cryptomator/cryptofs/common/Constants.java
@@ -17,7 +17,8 @@ public final class Constants {
 	public static final String MASTERKEY_BACKUP_SUFFIX = ".bkup";
 	public static final String DATA_DIR_NAME = "d";
 	public static final String ROOT_DIR_ID = "";
-	public static final String RECOVERY_DIR_ID = "l+f";
+	public static final String RECOVERY_DIR_ID = "recovery";
+
 	public static final String CRYPTOMATOR_FILE_SUFFIX = ".c9r";
 	public static final String DEFLATED_FILE_SUFFIX = ".c9s";
 	public static final String DIR_FILE_NAME = "dir.c9r";

--- a/src/main/java/org/cryptomator/cryptofs/common/Constants.java
+++ b/src/main/java/org/cryptomator/cryptofs/common/Constants.java
@@ -17,6 +17,7 @@ public final class Constants {
 	public static final String MASTERKEY_BACKUP_SUFFIX = ".bkup";
 	public static final String DATA_DIR_NAME = "d";
 	public static final String ROOT_DIR_ID = "";
+	public static final String RECOVERY_DIR_ID = "l+f";
 	public static final String CRYPTOMATOR_FILE_SUFFIX = ".c9r";
 	public static final String DEFLATED_FILE_SUFFIX = ".c9s";
 	public static final String DIR_FILE_NAME = "dir.c9r";
@@ -29,4 +30,5 @@ public final class Constants {
 	public static final int MAX_DIR_FILE_LENGTH = 36; // UUIDv4: hex-encoded 16 byte int + 4 hyphens = 36 ASCII chars
 
 	public static final String SEPARATOR = "/";
+	public static final String RECOVERY_DIR_NAME = "CRYPTOMATOR_RECOVERY";
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/api/DiagnosticResult.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/api/DiagnosticResult.java
@@ -4,6 +4,7 @@ import org.cryptomator.cryptofs.VaultConfig;
 import org.cryptomator.cryptolib.api.Cryptor;
 import org.cryptomator.cryptolib.api.Masterkey;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
 
@@ -39,7 +40,7 @@ public interface DiagnosticResult {
 	@Override
 	String toString();
 
-	default void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) {
+	default void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
 		throw new UnsupportedOperationException("Preliminary API not yet implemented");
 	}
 

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
@@ -119,9 +119,14 @@ public class OrphanDir implements DiagnosticResult {
 		//create "step-parent" directory to move orphaned files to
 		String cipherStepParentDirName = convertClearToCiphertext(cryptor, clearStepParentDirName, Constants.RECOVERY_DIR_ID);
 		Path cipherStepParentDirFile = cipherRecoveryDir.resolve(cipherStepParentDirName + "/" + Constants.DIR_FILE_NAME);
-		Files.createDirectory(cipherStepParentDirFile.getParent());
-		var stepParentUUID = UUID.randomUUID().toString();
-		Files.writeString(cipherStepParentDirFile, stepParentUUID, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+		final String stepParentUUID;
+		if (Files.exists(cipherStepParentDirFile, LinkOption.NOFOLLOW_LINKS)) {
+			stepParentUUID = Files.readString(cipherStepParentDirFile, StandardCharsets.UTF_8);
+		} else {
+			Files.createDirectory(cipherStepParentDirFile.getParent());
+			stepParentUUID = UUID.randomUUID().toString();
+			Files.writeString(cipherStepParentDirFile, stepParentUUID, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+		}
 		String stepParentDirHash = cryptor.hashDirectoryId(stepParentUUID);
 		Path stepParentDir = dataDir.resolve(stepParentDirHash.substring(0, 2)).resolve(stepParentDirHash.substring(2)).toAbsolutePath();
 		Files.createDirectories(stepParentDir);

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
@@ -65,7 +65,7 @@ public class OrphanDir implements DiagnosticResult {
 		Path orphanedDir = pathToVault.resolve(Constants.DATA_DIR_NAME).resolve(this.dir);
 		String orphanHash = dir.getParent().getFileName().toString() + dir.getFileName().toString();
 
-		var stepParentDir = prepareCryptoFilesystem(pathToVault, cryptor.fileNameCryptor(), orphanHash);
+		var stepParentDir = prepareStepParent(pathToVault, cryptor.fileNameCryptor(), orphanHash);
 
 		try (var orphanedContentStream = Files.newDirectoryStream(orphanedDir)) {
 			AtomicInteger fileCounter = new AtomicInteger(1);
@@ -86,7 +86,7 @@ public class OrphanDir implements DiagnosticResult {
 	}
 
 	// visible for testing
-	CryptoPathMapper.CiphertextDirectory prepareCryptoFilesystem(Path pathToVault, FileNameCryptor cryptor, String clearStepParentDirName) throws IOException {
+	CryptoPathMapper.CiphertextDirectory prepareStepParent(Path pathToVault, FileNameCryptor cryptor, String clearStepParentDirName) throws IOException {
 		//determine path for cipher root
 		Path dataDir = pathToVault.resolve(Constants.DATA_DIR_NAME);
 		String rootDirHash = cryptor.hashDirectoryId(Constants.ROOT_DIR_ID);

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
@@ -69,8 +69,9 @@ public class OrphanDir implements DiagnosticResult {
 
 	@Override
 	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
+		String runId = BaseEncoding.base64Url().encode(SHA1_HASHER.digest(UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8))).substring(0,3);
 		Path orphanedDir = pathToVault.resolve(Constants.DATA_DIR_NAME).resolve(this.dir);
-		String orphanHash = dir.getParent().getFileName().toString() + dir.getFileName().toString(); //TODO: is this the way? -> if the process is midterm aborted and later retried files already exist!
+		String orphanHash = dir.getParent().getFileName().toString() + dir.getFileName().toString();
 
 		var stepParentDir = prepareCryptoFilesystem(pathToVault, cryptor.fileNameCryptor(), orphanHash);
 
@@ -85,7 +86,7 @@ public class OrphanDir implements DiagnosticResult {
 					case FILE -> FILE_PREFIX + fileCounter.getAndIncrement();
 					case DIRECTORY -> DIR_PREFIX + dirCounter.getAndIncrement();
 					case SYMLINK -> SYMLINK_PREFIX + symlinkCounter.getAndIncrement();
-				};
+				} + "_" + runId;
 				adoptOrphanedResource(new Adoption(newClearName, orphanedResource), stepParentDir, cryptor.fileNameCryptor(), longNameSuffix);
 			}
 		}

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
@@ -170,7 +170,7 @@ public class OrphanDir implements DiagnosticResult {
 		try {
 			return MessageDigest.getInstance("SHA1");
 		} catch (NoSuchAlgorithmException e) {
-			throw new InstantiationError("Every JVM needs to provide a SHA1 implementation.");
+			throw new IllegalStateException("Every JVM needs to provide a SHA1 implementation.");
 		}
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
@@ -61,7 +61,7 @@ public class OrphanDir implements DiagnosticResult {
 	@Override
 	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
 		var sha1 = getSha1MessageDigest();
-		String runId = BaseEncoding.base64Url().encode(sha1.digest(UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8))).substring(0, 3);
+		String runId = Integer.toString((short) UUID.randomUUID().getMostSignificantBits(), 32);
 		Path orphanedDir = pathToVault.resolve(Constants.DATA_DIR_NAME).resolve(this.dir);
 		String orphanHash = dir.getParent().getFileName().toString() + dir.getFileName().toString();
 
@@ -100,7 +100,7 @@ public class OrphanDir implements DiagnosticResult {
 			Files.writeString(cipherRecoveryDirFile, Constants.RECOVERY_DIR_ID, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
 		} else {
 			String uuid = Files.readString(cipherRecoveryDirFile, StandardCharsets.UTF_8);
-			if (!uuid.equals(Constants.RECOVERY_DIR_ID)) {
+			if (!Constants.RECOVERY_DIR_ID.equals(uuid)) {
 				throw new FileAlreadyExistsException("Directory /" + Constants.RECOVERY_DIR_NAME + " already exists, but with wrong directory id.");
 			}
 		}

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
@@ -151,7 +151,7 @@ public class OrphanDir implements DiagnosticResult {
 	record Adoption(String newClearname, Path oldCipherPath) {}
 
 	private String createClearnameToBeShortened(int threshold) {
-		int neededLength = threshold / 4 * 3 - 16;
+		int neededLength = (threshold - 4) / 4 * 3 - 16;
 		return LONG_NAME_SUFFIX_BASE.repeat((neededLength % LONG_NAME_SUFFIX_BASE.length()) + 1);
 	}
 

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
@@ -1,7 +1,13 @@
 package org.cryptomator.cryptofs.health.dirid;
 
+import org.cryptomator.cryptofs.CryptoPath;
+import org.cryptomator.cryptofs.CryptoPathMapper;
+import org.cryptomator.cryptofs.VaultConfig;
 import org.cryptomator.cryptofs.health.api.DiagnosticResult;
+import org.cryptomator.cryptolib.api.Cryptor;
+import org.cryptomator.cryptolib.api.Masterkey;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
@@ -34,4 +40,21 @@ public class OrphanDir implements DiagnosticResult {
 	}
 
 	// fix: create new dirId inside of L+F dir and rename existing dir accordingly.
+	@Override
+	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) {
+		// open filesystem
+			//check if l+f dir exists
+			// if not, create it
+			// create new directory inside l+f with cleartext name based one orphandir path
+		// close filesystem
+
+		//find out dirId and ciphertextPath to the created directory
+
+		//for each resource in orphaned ciphertext dir:
+		//	move resource to unfiddled dir in l+f and rename resource  (use dirId for associated data)
+		//  distinct by directory, symlink and file
+		//  e.g. file1, file2, file3,...dir1, dir2, dir3,...,etc
+		//  don't forget shortend resource names
+		//remove empty, orphaned ciphertextdir
+	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
@@ -103,7 +103,7 @@ public class OrphanDir implements DiagnosticResult {
 		//create  if not existent with constant id
 		String cipherRecoveryDirName = convertClearToCiphertext(cryptor, Constants.RECOVERY_DIR_NAME, Constants.ROOT_DIR_ID);
 		Path cipherRecoveryDirFile = vaultCipherRootPath.resolve(cipherRecoveryDirName + "/" + Constants.DIR_FILE_NAME);
-		if (Files.notExists(cipherRecoveryDirFile)) {
+		if (Files.notExists(cipherRecoveryDirFile, LinkOption.NOFOLLOW_LINKS)) {
 			Files.createDirectory(cipherRecoveryDirFile.getParent());
 			Files.writeString(cipherRecoveryDirFile, Constants.RECOVERY_DIR_ID, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
 		} else {

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
@@ -1,15 +1,28 @@
 package org.cryptomator.cryptofs.health.dirid;
 
-import org.cryptomator.cryptofs.CryptoPath;
+import com.google.common.io.BaseEncoding;
+import org.cryptomator.cryptofs.CryptoFileSystemProperties;
+import org.cryptomator.cryptofs.CryptoFileSystemProvider;
 import org.cryptomator.cryptofs.CryptoPathMapper;
 import org.cryptomator.cryptofs.VaultConfig;
+import org.cryptomator.cryptofs.common.CiphertextFileType;
+import org.cryptomator.cryptofs.common.Constants;
 import org.cryptomator.cryptofs.health.api.DiagnosticResult;
 import org.cryptomator.cryptolib.api.Cryptor;
 import org.cryptomator.cryptolib.api.Masterkey;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.cryptomator.cryptofs.health.api.CommonDetailKeys.ENCRYPTED_PATH;
 
@@ -17,6 +30,8 @@ import static org.cryptomator.cryptofs.health.api.CommonDetailKeys.ENCRYPTED_PAT
  * An orphan directory is a detached node, not referenced by any dir.c9r file.
  */
 public class OrphanDir implements DiagnosticResult {
+
+	private static final String LOST_AND_FOUND_DIR = "lost+found";
 
 	final Path dir;
 
@@ -41,20 +56,108 @@ public class OrphanDir implements DiagnosticResult {
 
 	// fix: create new dirId inside of L+F dir and rename existing dir accordingly.
 	@Override
-	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) {
-		// open filesystem
-			//check if l+f dir exists
-			// if not, create it
-			// create new directory inside l+f with cleartext name based one orphandir path
-		// close filesystem
+	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
+		//open cryptofilsystem and place lf dir
+		Path orphanedDir = pathToVault.resolve(Constants.DATA_DIR_NAME).resolve(this.dir);
+		String orphanHash = dir.getParent().getFileName().toString() + dir.getFileName().toString(); //TODO: is this the way? -> if the process is midterm aborted and later retried files already exist!
+		try (var fs = CryptoFileSystemProvider.newFileSystem(pathToVault, CryptoFileSystemProperties.cryptoFileSystemProperties()
+				.withKeyLoader(uri -> masterkey.clone())
+				.withVaultConfigFilename("vault.cryptomator").build())) {
+			Path lf = fs.getRootDirectories().iterator().next().resolve(LOST_AND_FOUND_DIR);
+			Files.createDirectories(lf.resolve(orphanHash));
+		}
 
-		//find out dirId and ciphertextPath to the created directory
+		CryptoPathMapper.CiphertextDirectory cipherTargetDir = getCiphertextDirFileFromCleartext(cryptor, pathToVault, Path.of("/" + LOST_AND_FOUND_DIR + "/" + orphanHash));
 
-		//for each resource in orphaned ciphertext dir:
-		//	move resource to unfiddled dir in l+f and rename resource  (use dirId for associated data)
-		//  distinct by directory, symlink and file
-		//  e.g. file1, file2, file3,...dir1, dir2, dir3,...,etc
-		//  don't forget shortend resource names
-		//remove empty, orphaned ciphertextdir
+		if (!Files.exists(cipherTargetDir.path)) {
+			throw new IOException("Dir file of  not found " + cipherTargetDir.path);
+		}
+
+		try (var orphanedContentStream = Files.newDirectoryStream(orphanedDir)) {
+			//	move resource to unfiddled dir in l+f and rename resource  (use dirId for associated data)
+			AtomicInteger fileCounter = new AtomicInteger(1);
+			AtomicInteger dirCounter = new AtomicInteger(1);
+			AtomicInteger symlinkCounter = new AtomicInteger(1);
+			String filePrefix = "file";
+			String dirPrefix = "directory";
+			String symlinkPrefix = "symlink";
+			String veryLongSuffix = clearnameToBeDefinitelyShortend(cryptor, config.getShorteningThreshold());
+			MessageDigest sha1Hasher = MessageDigest.getInstance("SHA-1");
+
+			for (Path orphanedResource : orphanedContentStream) {
+				if (orphanedResource.toString().endsWith(Constants.DEFLATED_FILE_SUFFIX)) {
+					var newClearName = switch (determineCiphertextFileType(orphanedResource)) {
+						case FILE -> filePrefix + fileCounter.getAndIncrement();
+						case DIRECTORY -> dirPrefix + dirCounter.getAndIncrement();
+						case SYMLINK -> symlinkPrefix + symlinkCounter.getAndIncrement();
+					} + veryLongSuffix;
+					var newCipherName = convertClearToCiphertext(cryptor, newClearName, cipherTargetDir.dirId) + Constants.CRYPTOMATOR_FILE_SUFFIX;
+					//deflate
+					var deflatedName = BaseEncoding.base64Url().encode(sha1Hasher.digest(newCipherName.getBytes(StandardCharsets.UTF_8))) + Constants.DEFLATED_FILE_SUFFIX;
+					Path targetPath = cipherTargetDir.path.resolve(deflatedName);
+					Files.move(orphanedResource, targetPath, StandardCopyOption.ATOMIC_MOVE);
+
+					//adjust name.c9s
+					try (var fc = Files.newByteChannel(targetPath.resolve(Constants.INFLATED_FILE_NAME), StandardOpenOption.WRITE, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+						fc.write(ByteBuffer.wrap(newCipherName.getBytes(StandardCharsets.UTF_8)));
+					}
+				} else {
+					var newClearName = switch (determineCiphertextFileType(orphanedResource)) {
+						case FILE -> filePrefix + fileCounter.getAndIncrement();
+						case DIRECTORY -> dirPrefix + dirCounter.getAndIncrement();
+						case SYMLINK -> symlinkPrefix + symlinkCounter.getAndIncrement();
+					};
+					var newCipherName = convertClearToCiphertext(cryptor, newClearName, cipherTargetDir.dirId) + Constants.CRYPTOMATOR_FILE_SUFFIX;
+					Path targetPath = cipherTargetDir.path.resolve(newCipherName);
+					Files.move(orphanedResource, targetPath, StandardCopyOption.ATOMIC_MOVE);
+				}
+			}
+		} catch (NoSuchAlgorithmException e) {
+			throw new NoClassDefFoundError("Every JVM must implement SHA-1 algorithm.");
+		}
+		Files.delete(orphanedDir);
+	}
+
+	private String clearnameToBeDefinitelyShortend(Cryptor cryptor, int threshold) {
+		String base = "_withVeryLongName"; //all 1Byte chars in UTF8
+		int neededLength = (int) Math.ceil(threshold*0.75 -16);
+		if (neededLength > Integer.MAX_VALUE) {
+			//TODO
+			return "";
+		} else {
+			return base.repeat((neededLength % base.length()) + 1);
+		}
+	}
+
+	private CryptoPathMapper.CiphertextDirectory getCiphertextDirFileFromCleartext(Cryptor cryptor, Path pathToVault, Path cleartext) throws IOException {
+		String rootHash = cryptor.fileNameCryptor().hashDirectoryId(Constants.ROOT_DIR_ID);
+		Path vaultCipherRootPath = pathToVault.resolve(Constants.DATA_DIR_NAME).resolve(rootHash.substring(0, 2)).resolve(rootHash.substring(2)).toAbsolutePath();
+
+		String dirId = Constants.ROOT_DIR_ID;
+		Path target = vaultCipherRootPath;
+
+		for (Path component : cleartext) {
+			String ciphertextName = convertClearToCiphertext(cryptor, component.getFileName().toString(), dirId) + Constants.CRYPTOMATOR_FILE_SUFFIX;
+			Path dirFile = target.resolve(ciphertextName + "/" + Constants.DIR_FILE_NAME);
+			dirId = new String(Files.readAllBytes(dirFile), StandardCharsets.UTF_8);
+			String dirHash = cryptor.fileNameCryptor().hashDirectoryId(dirId);
+			target = pathToVault.resolve(Constants.DATA_DIR_NAME).resolve(dirHash.substring(0, 2)).resolve(dirHash.substring(2)).toAbsolutePath();
+		}
+
+		return new CryptoPathMapper.CiphertextDirectory(dirId, target);
+	}
+
+	private String convertClearToCiphertext(Cryptor cryptor, String clearTextName, String dirId) {
+		return cryptor.fileNameCryptor().encryptFilename(BaseEncoding.base64Url(), clearTextName, dirId.getBytes(StandardCharsets.UTF_8));
+	}
+
+	private CiphertextFileType determineCiphertextFileType(Path ciphertextPath) {
+		if (Files.exists(ciphertextPath.resolve(Constants.DIR_FILE_NAME), LinkOption.NOFOLLOW_LINKS)) {
+			return CiphertextFileType.DIRECTORY;
+		} else if (Files.exists(ciphertextPath.resolve(Constants.SYMLINK_FILE_NAME), LinkOption.NOFOLLOW_LINKS)) {
+			return CiphertextFileType.SYMLINK;
+		} else {
+			return CiphertextFileType.FILE;
+		}
 	}
 }

--- a/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
@@ -80,6 +80,7 @@ public class OrphanDirTest {
 		Path existingRecoveryDirFile = cipherRoot.resolve("1.c9r/dir.c9r");
 		Files.createDirectories(existingRecoveryDirFile.getParent());
 		Files.writeString(existingRecoveryDirFile, Constants.RECOVERY_DIR_ID, StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
+		Files.createDirectories(dataDir.resolve("11/1111"));
 
 		String clearStepParentName = "step-parent";
 		Mockito.doReturn("000000").when(cryptor).hashDirectoryId(Constants.ROOT_DIR_ID);
@@ -129,6 +130,42 @@ public class OrphanDirTest {
 		Assertions.assertTrue(Files.notExists(pathToVault.resolve("d/11/1111/2.c9r/dir.c9r")));
 		Assertions.assertTrue(Files.notExists(pathToVault.resolve("d/22/2222")));
 
+	}
+
+	@Test
+	@DisplayName("prepareCryptFileSystem() runs without error on existing stepparent")
+	public void testPrepareCryptoFSExistingStepParentDir() throws IOException {
+		Path existingRecoveryDirFile = cipherRoot.resolve("1.c9r/dir.c9r");
+		Files.createDirectories(existingRecoveryDirFile.getParent());
+		Files.writeString(existingRecoveryDirFile, Constants.RECOVERY_DIR_ID, StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
+		Path cipherRecovery = dataDir.resolve("11/1111");
+		Files.createDirectories(cipherRecovery);
+
+		Path existingStepparentDirFile = cipherRecovery.resolve("2.c9r/dir.c9r");
+		Files.createDirectories(existingStepparentDirFile.getParent());
+		Files.writeString(existingStepparentDirFile, "aaaaaa", StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
+		Path cipherStepparent = dataDir.resolve("22/2222");
+		Files.createDirectories(cipherStepparent);
+
+		String clearStepParentName = "step-parent";
+		Mockito.doReturn("000000").when(cryptor).hashDirectoryId(Constants.ROOT_DIR_ID);
+		Mockito.doReturn("111111").when(cryptor).hashDirectoryId(Constants.RECOVERY_DIR_ID);
+		Mockito.doReturn("222222").when(cryptor).hashDirectoryId("aaaaaa");
+
+		Mockito.doReturn("1").when(cryptor).encryptFilename(BaseEncoding.base64Url(), Constants.RECOVERY_DIR_NAME, Constants.ROOT_DIR_ID.getBytes(StandardCharsets.UTF_8));
+		Mockito.doReturn("2").when(cryptor).encryptFilename(BaseEncoding.base64Url(), clearStepParentName, Constants.RECOVERY_DIR_ID.getBytes(StandardCharsets.UTF_8));
+
+		try (var uuidClass = Mockito.mockStatic(UUID.class)) {
+			UUID uuid = Mockito.mock(UUID.class);
+			uuidClass.when(() -> UUID.randomUUID()).thenReturn(uuid);
+			Mockito.doReturn("aaaaaa").when(uuid).toString();
+
+			result.prepareCryptoFilesystem(pathToVault, cryptor, clearStepParentName);
+		}
+
+		Assertions.assertEquals(Constants.RECOVERY_DIR_ID, Files.readString(pathToVault.resolve("d/00/0000/1.c9r/dir.c9r"), StandardCharsets.UTF_8));
+		Assertions.assertEquals("aaaaaa", Files.readString(pathToVault.resolve("d/11/1111/2.c9r/dir.c9r"), StandardCharsets.UTF_8));
+		Assertions.assertTrue(Files.isDirectory(pathToVault.resolve("d/22/2222")));
 	}
 
 	@Test

--- a/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
@@ -145,7 +145,7 @@ public class OrphanDirTest {
 				uuidClass.when(() -> UUID.randomUUID()).thenReturn(uuid);
 				Mockito.doReturn("aaaaaa").when(uuid).toString();
 
-				result.prepareStepParent(cipherRecovery, cryptor, clearStepParentName);
+				result.prepareStepParent(dataDir, cipherRecovery, cryptor, clearStepParentName);
 			}
 
 			Assertions.assertEquals("aaaaaa", Files.readString(cipherRecovery.resolve("2.c9r/dir.c9r"), StandardCharsets.UTF_8));
@@ -166,7 +166,7 @@ public class OrphanDirTest {
 				uuidClass.when(() -> UUID.randomUUID()).thenReturn(uuid);
 				Mockito.doReturn("aaaaaa").when(uuid).toString();
 
-				result.prepareStepParent(cipherRecovery, cryptor, clearStepParentName);
+				result.prepareStepParent(dataDir, cipherRecovery, cryptor, clearStepParentName);
 			}
 
 			Assertions.assertEquals("aaaaaa", Files.readString(cipherRecovery.resolve("2.c9r/dir.c9r"), StandardCharsets.UTF_8));
@@ -187,7 +187,7 @@ public class OrphanDirTest {
 				uuidClass.when(() -> UUID.randomUUID()).thenReturn(uuid);
 				Mockito.doReturn("aaaaaa").when(uuid).toString();
 
-				result.prepareStepParent(cipherRecovery, cryptor, clearStepParentName);
+				result.prepareStepParent(dataDir, cipherRecovery, cryptor, clearStepParentName);
 			}
 
 			Assertions.assertEquals("aaaaaa", Files.readString(cipherRecovery.resolve("2.c9r/dir.c9r"), StandardCharsets.UTF_8));
@@ -298,7 +298,7 @@ public class OrphanDirTest {
 		Mockito.doReturn(cryptor).when(generalCryptor).fileNameCryptor();
 
 		Mockito.doReturn(cipherRecovery).when(resultSpy).prepareRecoveryDir(pathToVault, cryptor);
-		Mockito.doReturn(stepParentDir).when(resultSpy).prepareStepParent(Mockito.eq(cipherRecovery), Mockito.eq(cryptor), Mockito.any());
+		Mockito.doReturn(stepParentDir).when(resultSpy).prepareStepParent(Mockito.eq(dataDir), Mockito.eq(cipherRecovery), Mockito.eq(cryptor), Mockito.any());
 		Mockito.doAnswer(invocationOnMock -> {
 			Files.delete((Path) invocationOnMock.getArgument(0));
 			return null;
@@ -326,19 +326,19 @@ public class OrphanDirTest {
 		var interruptedSpy = Mockito.spy(interruptedResult);
 		Mockito.doReturn(cipherRecovery).when(interruptedSpy).prepareRecoveryDir(pathToVault, cryptor);
 		Mockito.doAnswer(invocation -> {
-			clearStepparentNameRef.set((String) invocation.getArgument(2));
+			clearStepparentNameRef.set((String) invocation.getArgument(3));
 			throw new IOException("Interrupt");
-		}).when(interruptedSpy).prepareStepParent(Mockito.eq(cipherRecovery), Mockito.eq(cryptor), Mockito.any());
+		}).when(interruptedSpy).prepareStepParent(Mockito.eq(dataDir), Mockito.eq(cipherRecovery), Mockito.eq(cryptor), Mockito.any());
 
 		var continuedResult = new OrphanDir(dataDir.relativize(cipherOrphan));
 		var continuedSpy = Mockito.spy(continuedResult);
 		Mockito.doReturn(cipherRecovery).when(continuedSpy).prepareRecoveryDir(pathToVault, cryptor);
-		Mockito.doThrow(IOException.class).when(continuedSpy).prepareStepParent(Mockito.any(), Mockito.any(), Mockito.any());
+		Mockito.doThrow(IOException.class).when(continuedSpy).prepareStepParent(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
 
 		Assertions.assertThrows(IOException.class, () -> interruptedSpy.fix(pathToVault, config, masterkey, generalCryptor));
 		Assertions.assertThrows(IOException.class, () -> continuedSpy.fix(pathToVault, config, masterkey, generalCryptor));
 
-		Mockito.verify(continuedSpy).prepareStepParent(cipherRecovery, cryptor, clearStepparentNameRef.get());
+		Mockito.verify(continuedSpy).prepareStepParent(dataDir, cipherRecovery, cryptor, clearStepparentNameRef.get());
 	}
 
 
@@ -364,7 +364,7 @@ public class OrphanDirTest {
 
 		resultSpy.fix(pathToVault, config, masterkey, generalCryptor);
 
-		Mockito.verify(resultSpy, Mockito.never()).prepareStepParent(Mockito.eq(cipherRecovery), Mockito.eq(cryptor), Mockito.any());
+		Mockito.verify(resultSpy, Mockito.never()).prepareStepParent(Mockito.eq(dataDir), Mockito.eq(cipherRecovery), Mockito.eq(cryptor), Mockito.any());
 		Mockito.verify(resultSpy, Mockito.never()).adoptOrphanedResource(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.eq(cryptor), Mockito.any(), Mockito.any());
 		Mockito.verify(resultSpy).prepareRecoveryDir(pathToVault, cryptor);
 	}

--- a/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
@@ -33,6 +33,7 @@ public class OrphanDirTest {
 	private OrphanDir result;
 	private Path dataDir;
 	private Path cipherRoot;
+	private Path cipherRecovery;
 	private Path cipherOrphan;
 	private FileNameCryptor cryptor;
 
@@ -43,6 +44,7 @@ public class OrphanDirTest {
 
 		dataDir = pathToVault.resolve("d");
 		cipherRoot = dataDir.resolve("00/0000");
+		cipherRecovery = dataDir.resolve("11/1111");
 		cipherOrphan = dataDir.resolve("33/3333");
 		Files.createDirectories(cipherRoot);
 		Files.createDirectories(cipherOrphan);
@@ -52,92 +54,107 @@ public class OrphanDirTest {
 
 
 	@Nested
-	class PrepareStepParentTests {
-
-		private String clearStepParentName;
+	class PrepareRecoveryDirTests {
 
 		@BeforeEach
 		public void init() {
-			clearStepParentName = "step-parent";
-			cryptor = Mockito.mock(FileNameCryptor.class);
 			Mockito.doReturn("000000").when(cryptor).hashDirectoryId(Constants.ROOT_DIR_ID);
 			Mockito.doReturn("111111").when(cryptor).hashDirectoryId(Constants.RECOVERY_DIR_ID);
 			Mockito.doReturn("222222").when(cryptor).hashDirectoryId("aaaaaa");
 
 			Mockito.doReturn("1").when(cryptor).encryptFilename(BaseEncoding.base64Url(), Constants.RECOVERY_DIR_NAME, Constants.ROOT_DIR_ID.getBytes(StandardCharsets.UTF_8));
-			Mockito.doReturn("2").when(cryptor).encryptFilename(BaseEncoding.base64Url(), clearStepParentName, Constants.RECOVERY_DIR_ID.getBytes(StandardCharsets.UTF_8));
 		}
 
 
 		@Test
-		@DisplayName("prepareStepParent() runs without error on not existing recovery dir")
+		@DisplayName("prepareRecoveryDir() creates recovery dir if not existent")
 		public void testPrepareStepParentNonExistingRecoveryDir() throws IOException {
-			try (var uuidClass = Mockito.mockStatic(UUID.class)) {
-				UUID uuid = Mockito.mock(UUID.class);
-				uuidClass.when(() -> UUID.randomUUID()).thenReturn(uuid);
-				Mockito.doReturn("aaaaaa").when(uuid).toString();
+			Path actualCipherDir = result.prepareRecoveryDir(pathToVault, cryptor);
 
-				result.prepareStepParent(pathToVault, cryptor, clearStepParentName);
-			}
-
+			Assertions.assertEquals(cipherRecovery, actualCipherDir);
 			Assertions.assertEquals(Constants.RECOVERY_DIR_ID, Files.readString(pathToVault.resolve("d/00/0000/1.c9r/dir.c9r"), StandardCharsets.UTF_8));
-			Assertions.assertEquals("aaaaaa", Files.readString(pathToVault.resolve("d/11/1111/2.c9r/dir.c9r"), StandardCharsets.UTF_8));
-			Assertions.assertTrue(Files.isDirectory(pathToVault.resolve("d/22/2222")));
+			Assertions.assertTrue(Files.exists(cipherRecovery));
 		}
 
 
 		@Test
-		@DisplayName("prepareStepParent() runs without error on existing recovery dir")
+		@DisplayName("prepareRecoveryDir() runs without error on existing recovery dir")
 		public void testPrepareStepParentExistingRecoveryDir() throws IOException {
 			Path existingRecoveryDirFile = cipherRoot.resolve("1.c9r/dir.c9r");
 			Files.createDirectories(existingRecoveryDirFile.getParent());
 			Files.writeString(existingRecoveryDirFile, Constants.RECOVERY_DIR_ID, StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
-			Files.createDirectories(dataDir.resolve("11/1111"));
+			Files.createDirectories(cipherRecovery);
 
-			try (var uuidClass = Mockito.mockStatic(UUID.class)) {
-				UUID uuid = Mockito.mock(UUID.class);
-				uuidClass.when(() -> UUID.randomUUID()).thenReturn(uuid);
-				Mockito.doReturn("aaaaaa").when(uuid).toString();
+			Path actualCipherDir = result.prepareRecoveryDir(pathToVault, cryptor);
 
-				result.prepareStepParent(pathToVault, cryptor, clearStepParentName);
-			}
-
+			Assertions.assertEquals(cipherRecovery, actualCipherDir);
 			Assertions.assertEquals(Constants.RECOVERY_DIR_ID, Files.readString(pathToVault.resolve("d/00/0000/1.c9r/dir.c9r"), StandardCharsets.UTF_8));
-			Assertions.assertEquals("aaaaaa", Files.readString(pathToVault.resolve("d/11/1111/2.c9r/dir.c9r"), StandardCharsets.UTF_8));
-			Assertions.assertTrue(Files.isDirectory(pathToVault.resolve("d/22/2222")));
+			Assertions.assertTrue(Files.isDirectory(cipherRecovery));
 		}
 
 
 		@Test
-		@DisplayName("prepareStepParent() throws exception on existing recovery dir with wrong id")
+		@DisplayName("prepareRecoveryDir() simply integrates orphaned recovery dir")
+		public void testPrepareStepParentOrphanedRecoveryDir() throws IOException {
+			Path missingRecoveryDirFile = cipherRoot.resolve("1.c9r/dir.c9r");
+			Files.createDirectories(missingRecoveryDirFile.getParent());
+			Files.createDirectories(cipherRecovery);
+
+			Path actualCipherDir = result.prepareRecoveryDir(pathToVault, cryptor);
+
+			Assertions.assertEquals(cipherRecovery, actualCipherDir);
+			Assertions.assertEquals(Constants.RECOVERY_DIR_ID, Files.readString(pathToVault.resolve("d/00/0000/1.c9r/dir.c9r"), StandardCharsets.UTF_8));
+			Assertions.assertTrue(Files.isDirectory(cipherRecovery));
+		}
+
+
+		@Test
+		@DisplayName("prepareRecoveryDir() throws exception on existing recovery dir with wrong id")
 		public void testPrepareStepParentWithWrongRecoveryDir() throws IOException {
 			Path existingRecoveryDirFile = cipherRoot.resolve("1.c9r/dir.c9r");
 			Files.createDirectories(existingRecoveryDirFile.getParent());
 			Files.writeString(existingRecoveryDirFile, UUID.randomUUID().toString(), StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
 
+			Assertions.assertThrows(FileAlreadyExistsException.class, () -> result.prepareRecoveryDir(pathToVault, cryptor));
+
+			Assertions.assertNotEquals(Constants.RECOVERY_DIR_ID, Files.readString(existingRecoveryDirFile, StandardCharsets.UTF_8));
+		}
+	}
+
+
+	@Nested
+	class PrepareStepParentTests {
+
+		private String clearStepParentName;
+
+		@BeforeEach
+		public void init() throws IOException {
+			clearStepParentName = "step-parent";
+			Files.createDirectories(cipherRecovery);
+
+			Mockito.doReturn("222222").when(cryptor).hashDirectoryId("aaaaaa");
+			Mockito.doReturn("1").when(cryptor).encryptFilename(BaseEncoding.base64Url(), Constants.RECOVERY_DIR_NAME, Constants.ROOT_DIR_ID.getBytes(StandardCharsets.UTF_8));
+			Mockito.doReturn("2").when(cryptor).encryptFilename(BaseEncoding.base64Url(), clearStepParentName, Constants.RECOVERY_DIR_ID.getBytes(StandardCharsets.UTF_8));
+		}
+
+		@Test
+		@DisplayName("prepareStepParent() runs without error on not-existing stepparent")
+		public void testPrepareStepParent() throws IOException {
 			try (var uuidClass = Mockito.mockStatic(UUID.class)) {
 				UUID uuid = Mockito.mock(UUID.class);
 				uuidClass.when(() -> UUID.randomUUID()).thenReturn(uuid);
 				Mockito.doReturn("aaaaaa").when(uuid).toString();
 
-				Assertions.assertThrows(FileAlreadyExistsException.class, () -> result.prepareStepParent(pathToVault, cryptor, clearStepParentName));
+				result.prepareStepParent(cipherRecovery, cryptor, clearStepParentName);
 			}
 
-			Assertions.assertNotEquals(Constants.RECOVERY_DIR_ID, Files.readString(pathToVault.resolve("d/00/0000/1.c9r/dir.c9r"), StandardCharsets.UTF_8));
-			Assertions.assertTrue(Files.notExists(pathToVault.resolve("d/11/1111/2.c9r/dir.c9r")));
-			Assertions.assertTrue(Files.notExists(pathToVault.resolve("d/22/2222")));
+			Assertions.assertEquals("aaaaaa", Files.readString(cipherRecovery.resolve("2.c9r/dir.c9r"), StandardCharsets.UTF_8));
+			Assertions.assertTrue(Files.isDirectory(pathToVault.resolve("d/22/2222")));
 		}
-
 
 		@Test
 		@DisplayName("prepareStepParent() runs without error on existing stepparent")
 		public void testPrepareStepParentExistingStepParentDir() throws IOException {
-			Path existingRecoveryDirFile = cipherRoot.resolve("1.c9r/dir.c9r");
-			Files.createDirectories(existingRecoveryDirFile.getParent());
-			Files.writeString(existingRecoveryDirFile, Constants.RECOVERY_DIR_ID, StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
-			Path cipherRecovery = dataDir.resolve("11/1111");
-			Files.createDirectories(cipherRecovery);
-
 			Path existingStepparentDirFile = cipherRecovery.resolve("2.c9r/dir.c9r");
 			Files.createDirectories(existingStepparentDirFile.getParent());
 			Files.writeString(existingStepparentDirFile, "aaaaaa", StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
@@ -149,11 +166,31 @@ public class OrphanDirTest {
 				uuidClass.when(() -> UUID.randomUUID()).thenReturn(uuid);
 				Mockito.doReturn("aaaaaa").when(uuid).toString();
 
-				result.prepareStepParent(pathToVault, cryptor, clearStepParentName);
+				result.prepareStepParent(cipherRecovery, cryptor, clearStepParentName);
 			}
 
-			Assertions.assertEquals(Constants.RECOVERY_DIR_ID, Files.readString(pathToVault.resolve("d/00/0000/1.c9r/dir.c9r"), StandardCharsets.UTF_8));
-			Assertions.assertEquals("aaaaaa", Files.readString(pathToVault.resolve("d/11/1111/2.c9r/dir.c9r"), StandardCharsets.UTF_8));
+			Assertions.assertEquals("aaaaaa", Files.readString(cipherRecovery.resolve("2.c9r/dir.c9r"), StandardCharsets.UTF_8));
+			Assertions.assertTrue(Files.isDirectory(pathToVault.resolve("d/22/2222")));
+		}
+
+
+		@Test
+		@DisplayName("prepareStepParent() runs without error on orphaned stepparent")
+		public void testPrepareStepParentOrphanedStepParentDir() throws IOException {
+			Path missingStepparentDirFile = cipherRecovery.resolve("2.c9r/dir.c9r");
+			Files.createDirectories(missingStepparentDirFile.getParent());
+			Path cipherStepparent = dataDir.resolve("22/2222");
+			Files.createDirectories(cipherStepparent);
+
+			try (var uuidClass = Mockito.mockStatic(UUID.class)) {
+				UUID uuid = Mockito.mock(UUID.class);
+				uuidClass.when(() -> UUID.randomUUID()).thenReturn(uuid);
+				Mockito.doReturn("aaaaaa").when(uuid).toString();
+
+				result.prepareStepParent(cipherRecovery, cryptor, clearStepParentName);
+			}
+
+			Assertions.assertEquals("aaaaaa", Files.readString(cipherRecovery.resolve("2.c9r/dir.c9r"), StandardCharsets.UTF_8));
 			Assertions.assertTrue(Files.isDirectory(pathToVault.resolve("d/22/2222")));
 		}
 	}
@@ -256,7 +293,8 @@ public class OrphanDirTest {
 		Cryptor generalCryptor = Mockito.mock(Cryptor.class);
 		Mockito.doReturn(cryptor).when(generalCryptor).fileNameCryptor();
 
-		Mockito.doReturn(stepParentDir).when(resultSpy).prepareStepParent(Mockito.eq(pathToVault), Mockito.eq(cryptor), Mockito.any());
+		Mockito.doReturn(cipherRecovery).when(resultSpy).prepareRecoveryDir(pathToVault, cryptor);
+		Mockito.doReturn(stepParentDir).when(resultSpy).prepareStepParent(Mockito.eq(cipherRecovery), Mockito.eq(cryptor), Mockito.any());
 		Mockito.doAnswer(invocationOnMock -> {
 			Files.delete((Path) invocationOnMock.getArgument(0));
 			return null;
@@ -268,10 +306,10 @@ public class OrphanDirTest {
 		Assertions.assertTrue(Files.notExists(cipherOrphan));
 	}
 
-	
+
 	@Test
 	@DisplayName("results with same orphan have write to same cleartext stepparent")
-	public void testfixRepeated() throws IOException {
+	public void testFixRepeated() throws IOException {
 		VaultConfig config = Mockito.mock(VaultConfig.class);
 		Mockito.doReturn(170).when(config).getShorteningThreshold();
 		Masterkey masterkey = Mockito.mock(Masterkey.class);
@@ -282,18 +320,48 @@ public class OrphanDirTest {
 
 		var interruptedResult = new OrphanDir(dataDir.relativize(cipherOrphan));
 		var interruptedSpy = Mockito.spy(interruptedResult);
+		Mockito.doReturn(cipherRecovery).when(interruptedSpy).prepareRecoveryDir(pathToVault, cryptor);
 		Mockito.doAnswer(invocation -> {
 			clearStepparentNameRef.set((String) invocation.getArgument(2));
 			throw new IOException("Interrupt");
-		}).when(interruptedSpy).prepareStepParent(Mockito.eq(pathToVault), Mockito.eq(cryptor), Mockito.any());
+		}).when(interruptedSpy).prepareStepParent(Mockito.eq(cipherRecovery), Mockito.eq(cryptor), Mockito.any());
 
 		var continuedResult = new OrphanDir(dataDir.relativize(cipherOrphan));
 		var continuedSpy = Mockito.spy(continuedResult);
+		Mockito.doReturn(cipherRecovery).when(continuedSpy).prepareRecoveryDir(pathToVault, cryptor);
 		Mockito.doThrow(IOException.class).when(continuedSpy).prepareStepParent(Mockito.any(), Mockito.any(), Mockito.any());
 
 		Assertions.assertThrows(IOException.class, () -> interruptedSpy.fix(pathToVault, config, masterkey, generalCryptor));
 		Assertions.assertThrows(IOException.class, () -> continuedSpy.fix(pathToVault, config, masterkey, generalCryptor));
 
-		Mockito.verify(continuedSpy).prepareStepParent(pathToVault, cryptor, clearStepparentNameRef.get());
+		Mockito.verify(continuedSpy).prepareStepParent(cipherRecovery, cryptor, clearStepparentNameRef.get());
+	}
+
+
+	@Test
+	@DisplayName("orphaned recovery dir will only be reintegrated")
+	public void testFixOrphanedRecoveryDir() throws IOException {
+		Path orphanedRecovery = dataDir.resolve("11/1111");
+		result = new OrphanDir(dataDir.relativize(orphanedRecovery));
+		var resultSpy = Mockito.spy(result);
+
+		Path orphan1 = orphanedRecovery.resolve("orphan1.c9r");
+		Path orphan2 = orphanedRecovery.resolve("orphan2.c9r");
+		Files.createDirectories(orphan1);
+		Files.createDirectories(orphan2);
+
+
+		VaultConfig config = Mockito.mock(VaultConfig.class);
+		Mockito.doReturn(170).when(config).getShorteningThreshold();
+		Masterkey masterkey = Mockito.mock(Masterkey.class);
+		Cryptor generalCryptor = Mockito.mock(Cryptor.class);
+		Mockito.doReturn(cryptor).when(generalCryptor).fileNameCryptor();
+		Mockito.doReturn(cipherRecovery).when(resultSpy).prepareRecoveryDir(pathToVault, cryptor);
+
+		resultSpy.fix(pathToVault, config, masterkey, generalCryptor);
+
+		Mockito.verify(resultSpy, Mockito.never()).prepareStepParent(Mockito.eq(cipherRecovery), Mockito.eq(cryptor), Mockito.any());
+		Mockito.verify(resultSpy, Mockito.never()).adoptOrphanedResource(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.eq(cryptor), Mockito.any(), Mockito.any());
+		Mockito.verify(resultSpy).prepareRecoveryDir(pathToVault, cryptor);
 	}
 }

--- a/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
@@ -180,8 +180,9 @@ public class OrphanDirTest {
 		Files.createDirectories(stepParentDir.path);
 
 		Mockito.doReturn("adopted").when(cryptor).encryptFilename(BaseEncoding.base64Url(), adoption.newClearname(), stepParentDir.dirId.getBytes(StandardCharsets.UTF_8));
+		var sha1 = Mockito.mock(MessageDigest.class);
 
-		result.adoptOrphanedResource(adoption, stepParentDir, cryptor, "longNameSuffix");
+		result.adoptOrphanedResource(adoption, stepParentDir, cryptor, "longNameSuffix", sha1);
 
 		Assertions.assertEquals(expectedMsg, Files.readString(stepParentDir.path.resolve("adopted.c9r")));
 		Assertions.assertTrue(Files.notExists(adoption.oldCipherPath()));
@@ -198,17 +199,15 @@ public class OrphanDirTest {
 		Files.createDirectories(stepParentDir.path);
 
 		Mockito.doReturn("adopted").when(cryptor).encryptFilename(Mockito.any(), Mockito.any(), Mockito.any());
-		try (var messageDigestClass = Mockito.mockStatic(MessageDigest.class); //
-			 var baseEncodingClass = Mockito.mockStatic(BaseEncoding.class)) {
+		try (var baseEncodingClass = Mockito.mockStatic(BaseEncoding.class)) {
 			MessageDigest sha1 = Mockito.mock(MessageDigest.class);
-			messageDigestClass.when(() -> MessageDigest.getInstance("SHA1")).thenReturn(sha1);
 			Mockito.doReturn(new byte[]{}).when(sha1).digest(Mockito.any());
 
 			BaseEncoding base64url = Mockito.mock(BaseEncoding.class);
 			baseEncodingClass.when(() -> BaseEncoding.base64Url()).thenReturn(base64url);
 			Mockito.doReturn("adopted_shortened").when(base64url).encode(Mockito.any());
 
-			result.adoptOrphanedResource(adoption, stepParentDir, cryptor, "");
+			result.adoptOrphanedResource(adoption, stepParentDir, cryptor, "", sha1);
 		}
 
 		Assertions.assertTrue(Files.exists(stepParentDir.path.resolve("adopted_shortened.c9s")));
@@ -227,17 +226,15 @@ public class OrphanDirTest {
 		Files.createDirectories(stepParentDir.path);
 
 		Mockito.doReturn("adopted").when(cryptor).encryptFilename(Mockito.any(), Mockito.any(), Mockito.any());
-		try (var messageDigestClass = Mockito.mockStatic(MessageDigest.class); //
-			 var baseEncodingClass = Mockito.mockStatic(BaseEncoding.class)) {
+		try (var baseEncodingClass = Mockito.mockStatic(BaseEncoding.class)) {
 			MessageDigest sha1 = Mockito.mock(MessageDigest.class);
-			messageDigestClass.when(() -> MessageDigest.getInstance("SHA1")).thenReturn(sha1);
 			Mockito.doReturn(new byte[]{}).when(sha1).digest(Mockito.any());
 
 			BaseEncoding base64url = Mockito.mock(BaseEncoding.class);
 			baseEncodingClass.when(() -> BaseEncoding.base64Url()).thenReturn(base64url);
 			Mockito.doReturn("adopted_shortened").when(base64url).encode(Mockito.any());
 
-			result.adoptOrphanedResource(adoption, stepParentDir, cryptor, "");
+			result.adoptOrphanedResource(adoption, stepParentDir, cryptor, "", sha1);
 		}
 
 		Assertions.assertTrue(Files.exists(stepParentDir.path.resolve("adopted_shortened.c9s")));
@@ -269,11 +266,11 @@ public class OrphanDirTest {
 			var adoption = (OrphanDir.Adoption) invocationOnMock.getArgument(0);
 			Files.delete(adoption.oldCipherPath());
 			return null;
-		}).when(resultSpy).adoptOrphanedResource(Mockito.any(), Mockito.eq(stepParentDir), Mockito.eq(cryptor), Mockito.any());
+		}).when(resultSpy).adoptOrphanedResource(Mockito.any(), Mockito.eq(stepParentDir), Mockito.eq(cryptor), Mockito.any(), Mockito.any());
 
 		resultSpy.fix(pathToVault, config, masterkey, generalCryptor);
 
-		Mockito.verify(resultSpy, Mockito.times(2)).adoptOrphanedResource(Mockito.any(), Mockito.eq(stepParentDir), Mockito.eq(cryptor), Mockito.any());
+		Mockito.verify(resultSpy, Mockito.times(2)).adoptOrphanedResource(Mockito.any(), Mockito.eq(stepParentDir), Mockito.eq(cryptor), Mockito.any(), Mockito.any());
 		Assertions.assertTrue(Files.notExists(cipherOrphan));
 	}
 

--- a/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
@@ -50,8 +50,8 @@ public class OrphanDirTest {
 	}
 
 	@Test
-	@DisplayName("prepareCryptFileSystem() runs without error on not existing recovery dir")
-	public void testPrepareCryptoFileSystemNonExistingRecoveryDir() throws IOException {
+	@DisplayName("prepareStepParent() runs without error on not existing recovery dir")
+	public void testPrepareStepParentNonExistingRecoveryDir() throws IOException {
 		String clearStepParentName = "step-parent";
 		FileNameCryptor cryptor = Mockito.mock(FileNameCryptor.class);
 		Mockito.doReturn("000000").when(cryptor).hashDirectoryId(Constants.ROOT_DIR_ID);
@@ -66,7 +66,7 @@ public class OrphanDirTest {
 			uuidClass.when(() -> UUID.randomUUID()).thenReturn(uuid);
 			Mockito.doReturn("aaaaaa").when(uuid).toString();
 
-			result.prepareCryptoFilesystem(pathToVault, cryptor, clearStepParentName);
+			result.prepareStepParent(pathToVault, cryptor, clearStepParentName);
 		}
 
 		Assertions.assertEquals(Constants.RECOVERY_DIR_ID, Files.readString(pathToVault.resolve("d/00/0000/1.c9r/dir.c9r"), StandardCharsets.UTF_8));
@@ -76,8 +76,8 @@ public class OrphanDirTest {
 	}
 
 	@Test
-	@DisplayName("prepareCryptFileSystem() runs without error on existing recovery dir")
-	public void testPrepareCryptoFileSystemExistingRecoveryDir() throws IOException {
+	@DisplayName("prepareStepParent() runs without error on existing recovery dir")
+	public void testPrepareStepParentExistingRecoveryDir() throws IOException {
 		Path existingRecoveryDirFile = cipherRoot.resolve("1.c9r/dir.c9r");
 		Files.createDirectories(existingRecoveryDirFile.getParent());
 		Files.writeString(existingRecoveryDirFile, Constants.RECOVERY_DIR_ID, StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
@@ -96,7 +96,7 @@ public class OrphanDirTest {
 			uuidClass.when(() -> UUID.randomUUID()).thenReturn(uuid);
 			Mockito.doReturn("aaaaaa").when(uuid).toString();
 
-			result.prepareCryptoFilesystem(pathToVault, cryptor, clearStepParentName);
+			result.prepareStepParent(pathToVault, cryptor, clearStepParentName);
 		}
 
 		Assertions.assertEquals(Constants.RECOVERY_DIR_ID, Files.readString(pathToVault.resolve("d/00/0000/1.c9r/dir.c9r"), StandardCharsets.UTF_8));
@@ -105,8 +105,8 @@ public class OrphanDirTest {
 	}
 
 	@Test
-	@DisplayName("prepareCryptFileSystem() throws exception on existing recovery dir with wrong id")
-	public void testPrepareCryptoFSWithWrongRecoveryDir() throws IOException {
+	@DisplayName("prepareStepParent() throws exception on existing recovery dir with wrong id")
+	public void testPrepareStepParentWithWrongRecoveryDir() throws IOException {
 		Path existingRecoveryDirFile = cipherRoot.resolve("1.c9r/dir.c9r");
 		Files.createDirectories(existingRecoveryDirFile.getParent());
 		Files.writeString(existingRecoveryDirFile, UUID.randomUUID().toString(), StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
@@ -124,7 +124,7 @@ public class OrphanDirTest {
 			uuidClass.when(() -> UUID.randomUUID()).thenReturn(uuid);
 			Mockito.doReturn("aaaaaa").when(uuid).toString();
 
-			Assertions.assertThrows(FileAlreadyExistsException.class, () -> result.prepareCryptoFilesystem(pathToVault, cryptor, clearStepParentName));
+			Assertions.assertThrows(FileAlreadyExistsException.class, () -> result.prepareStepParent(pathToVault, cryptor, clearStepParentName));
 		}
 
 		Assertions.assertNotEquals(Constants.RECOVERY_DIR_ID, Files.readString(pathToVault.resolve("d/00/0000/1.c9r/dir.c9r"), StandardCharsets.UTF_8));
@@ -134,8 +134,8 @@ public class OrphanDirTest {
 	}
 
 	@Test
-	@DisplayName("prepareCryptFileSystem() runs without error on existing stepparent")
-	public void testPrepareCryptoFSExistingStepParentDir() throws IOException {
+	@DisplayName("prepareStepParent() runs without error on existing stepparent")
+	public void testPrepareStepParentExistingStepParentDir() throws IOException {
 		Path existingRecoveryDirFile = cipherRoot.resolve("1.c9r/dir.c9r");
 		Files.createDirectories(existingRecoveryDirFile.getParent());
 		Files.writeString(existingRecoveryDirFile, Constants.RECOVERY_DIR_ID, StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
@@ -161,7 +161,7 @@ public class OrphanDirTest {
 			uuidClass.when(() -> UUID.randomUUID()).thenReturn(uuid);
 			Mockito.doReturn("aaaaaa").when(uuid).toString();
 
-			result.prepareCryptoFilesystem(pathToVault, cryptor, clearStepParentName);
+			result.prepareStepParent(pathToVault, cryptor, clearStepParentName);
 		}
 
 		Assertions.assertEquals(Constants.RECOVERY_DIR_ID, Files.readString(pathToVault.resolve("d/00/0000/1.c9r/dir.c9r"), StandardCharsets.UTF_8));
@@ -264,7 +264,7 @@ public class OrphanDirTest {
 		Cryptor generalCryptor = Mockito.mock(Cryptor.class);
 		Mockito.doReturn(cryptor).when(generalCryptor).fileNameCryptor();
 
-		Mockito.doReturn(stepParentDir).when(resultSpy).prepareCryptoFilesystem(Mockito.eq(pathToVault), Mockito.eq(cryptor), Mockito.any());
+		Mockito.doReturn(stepParentDir).when(resultSpy).prepareStepParent(Mockito.eq(pathToVault), Mockito.eq(cryptor), Mockito.any());
 		Mockito.doAnswer(invocationOnMock -> {
 			Files.delete((Path) invocationOnMock.getArgument(0));
 			return null;
@@ -292,15 +292,15 @@ public class OrphanDirTest {
 		Mockito.doAnswer(invocation -> {
 			clearStepparentNameRef.set((String) invocation.getArgument(2));
 			throw new IOException("Interrupt");
-		}).when(interruptedSpy).prepareCryptoFilesystem(Mockito.eq(pathToVault), Mockito.eq(cryptor), Mockito.any());
+		}).when(interruptedSpy).prepareStepParent(Mockito.eq(pathToVault), Mockito.eq(cryptor), Mockito.any());
 
 		var continuedResult = new OrphanDir(dataDir.relativize(cipherOrphan));
 		var continuedSpy = Mockito.spy(continuedResult);
-		Mockito.doThrow(IOException.class).when(continuedSpy).prepareCryptoFilesystem(Mockito.any(), Mockito.any(), Mockito.any());
+		Mockito.doThrow(IOException.class).when(continuedSpy).prepareStepParent(Mockito.any(), Mockito.any(), Mockito.any());
 
 		Assertions.assertThrows(IOException.class, () -> interruptedSpy.fix(pathToVault, config, masterkey, generalCryptor));
 		Assertions.assertThrows(IOException.class, () -> continuedSpy.fix(pathToVault, config, masterkey, generalCryptor));
 
-		Mockito.verify(continuedSpy).prepareCryptoFilesystem(pathToVault, cryptor, clearStepparentNameRef.get());
+		Mockito.verify(continuedSpy).prepareStepParent(pathToVault, cryptor, clearStepparentNameRef.get());
 	}
 }

--- a/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
@@ -1,15 +1,14 @@
 package org.cryptomator.cryptofs.health.dirid;
 
 import com.google.common.io.BaseEncoding;
-import jdk.jfr.Name;
 import org.cryptomator.cryptofs.common.Constants;
 import org.cryptomator.cryptolib.api.FileNameCryptor;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
-import javax.inject.Named;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
@@ -24,6 +23,7 @@ public class OrphanDirTest {
 	public Path pathToVault;
 
 	@Test
+	@DisplayName("prepareCryptFileSystem() runs without error on not existing recovery dir")
 	public void testPrepareCryptoFileSystemNonExistingRecoveryDir() throws IOException {
 		Path p = Mockito.mock(Path.class, "ignored");
 		OrphanDir result = new OrphanDir(p);
@@ -55,14 +55,46 @@ public class OrphanDirTest {
 	}
 
 	@Test
-	@Name("test prepare fs method with a user created recovery id")
-	public void testPrepareCryptoFSWithRecoveryDirWrongId() throws IOException {
+	@DisplayName("prepareCryptFileSystem() runs without error on existing recovery dir")
+	public void testPrepareCryptoFileSystemExistingRecoveryDir() throws IOException {
 		Path p = Mockito.mock(Path.class, "ignored");
 		OrphanDir result = new OrphanDir(p);
 
 		Path userCreatedRecoveryDirFile = pathToVault.resolve("d/00/0000/1.c9r/dir.c9r");
 		Files.createDirectories(userCreatedRecoveryDirFile.getParent());
-		Files.writeString(userCreatedRecoveryDirFile,UUID.randomUUID().toString(),StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
+		Files.writeString(userCreatedRecoveryDirFile, Constants.RECOVERY_DIR_ID, StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
+
+		String clearStepParentName = "step-parent";
+		FileNameCryptor cryptor = Mockito.mock(FileNameCryptor.class);
+		Mockito.doReturn("000000").when(cryptor).hashDirectoryId(Constants.ROOT_DIR_ID);
+		Mockito.doReturn("111111").when(cryptor).hashDirectoryId(Constants.RECOVERY_DIR_ID);
+		Mockito.doReturn("222222").when(cryptor).hashDirectoryId("aaaaaa");
+
+		Mockito.doReturn("1").when(cryptor).encryptFilename(BaseEncoding.base64Url(), Constants.RECOVERY_DIR_NAME, Constants.ROOT_DIR_ID.getBytes(StandardCharsets.UTF_8));
+		Mockito.doReturn("2").when(cryptor).encryptFilename(BaseEncoding.base64Url(), clearStepParentName, Constants.RECOVERY_DIR_ID.getBytes(StandardCharsets.UTF_8));
+
+		try (var uuidClass = Mockito.mockStatic(UUID.class)) {
+			UUID uuid = Mockito.mock(UUID.class);
+			uuidClass.when(() -> UUID.randomUUID()).thenReturn(uuid);
+			Mockito.doReturn("aaaaaa").when(uuid).toString();
+
+			result.prepareCryptoFilesystem(pathToVault, cryptor, clearStepParentName);
+		}
+
+		Assertions.assertEquals(Constants.RECOVERY_DIR_ID, Files.readString(pathToVault.resolve("d/00/0000/1.c9r/dir.c9r"), StandardCharsets.UTF_8));
+		Assertions.assertEquals("aaaaaa", Files.readString(pathToVault.resolve("d/11/1111/2.c9r/dir.c9r"), StandardCharsets.UTF_8));
+		Assertions.assertTrue(Files.isDirectory(pathToVault.resolve("d/22/2222")));
+	}
+
+	@Test
+	@DisplayName("prepareCryptFileSystem() throws exception on existing recovery dir with wrong id")
+	public void testPrepareCryptoFSWithWrongRecoveryDir() throws IOException {
+		Path p = Mockito.mock(Path.class, "ignored");
+		OrphanDir result = new OrphanDir(p);
+
+		Path userCreatedRecoveryDirFile = pathToVault.resolve("d/00/0000/1.c9r/dir.c9r");
+		Files.createDirectories(userCreatedRecoveryDirFile.getParent());
+		Files.writeString(userCreatedRecoveryDirFile, UUID.randomUUID().toString(), StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
 
 		String clearStepParentName = "step-parent";
 		FileNameCryptor cryptor = Mockito.mock(FileNameCryptor.class);

--- a/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
@@ -39,7 +39,6 @@ public class OrphanDirTest {
 		dataDir = pathToVault.resolve("d");
 		cipherRoot = dataDir.resolve("00/0000");
 		cipherOrphan = dataDir.resolve("33/3333");
-
 		Files.createDirectories(cipherRoot);
 		Files.createDirectories(cipherOrphan);
 
@@ -150,8 +149,7 @@ public class OrphanDirTest {
 	@Test
 	@DisplayName("adoptOrphanedResource runs for shortened resource with existing name.c9s")
 	public void testAdoptOrphanedShortened() throws IOException {
-		Path orphanDir = pathToVault.resolve("d/33/3333/");
-		OrphanDir.Adoption adoption = new OrphanDir.Adoption("Jim Knopf", orphanDir.resolve("orphan.c9s"));
+		OrphanDir.Adoption adoption = new OrphanDir.Adoption("Jim Knopf", cipherOrphan.resolve("orphan.c9s"));
 		Files.createDirectories(adoption.oldCipherPath());
 		Files.createFile(adoption.oldCipherPath().resolve("name.c9s"));
 
@@ -181,8 +179,7 @@ public class OrphanDirTest {
 	@Test
 	@DisplayName("adoptOrphanedResource runs for shortened resource without existing name.c9s")
 	public void testAdoptOrphanedShortenedMissingNameC9s() throws IOException {
-		Path orphanDir = pathToVault.resolve("d/33/3333/");
-		OrphanDir.Adoption adoption = new OrphanDir.Adoption("Tom Sawyer", orphanDir.resolve("orphan.c9s"));
+		OrphanDir.Adoption adoption = new OrphanDir.Adoption("Tom Sawyer", cipherOrphan.resolve("orphan.c9s"));
 		Files.createDirectories(adoption.oldCipherPath());
 
 		CryptoPathMapper.CiphertextDirectory stepParentDir = new CryptoPathMapper.CiphertextDirectory("aaaaaa", pathToVault.resolve("d/22/2222"));

--- a/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
@@ -195,82 +195,86 @@ public class OrphanDirTest {
 		}
 	}
 
+	@Nested
+	class AdoptOrphanedTests {
 
-	@Test
-	@DisplayName("adoptOrphanedResource runs for unshortened resource")
-	public void testAdoptOrphanedUnshortened() throws IOException {
-		String expectedMsg = "Please, sir, I want some more.";
-		Path oldCipherPath = cipherOrphan.resolve("orphan.c9r");
-		String newClearName = "OliverTwist";
-		Files.writeString(oldCipherPath, expectedMsg, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+		@Test
+		@DisplayName("adoptOrphanedResource runs for unshortened resource")
+		public void testAdoptOrphanedUnshortened() throws IOException {
+			String expectedMsg = "Please, sir, I want some more.";
+			Path oldCipherPath = cipherOrphan.resolve("orphan.c9r");
+			String newClearName = "OliverTwist";
+			Files.writeString(oldCipherPath, expectedMsg, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
 
-		CryptoPathMapper.CiphertextDirectory stepParentDir = new CryptoPathMapper.CiphertextDirectory("aaaaaa", pathToVault.resolve("d/22/2222"));
-		Files.createDirectories(stepParentDir.path);
+			CryptoPathMapper.CiphertextDirectory stepParentDir = new CryptoPathMapper.CiphertextDirectory("aaaaaa", pathToVault.resolve("d/22/2222"));
+			Files.createDirectories(stepParentDir.path);
 
-		Mockito.doReturn("adopted").when(cryptor).encryptFilename(BaseEncoding.base64Url(), newClearName, stepParentDir.dirId.getBytes(StandardCharsets.UTF_8));
-		var sha1 = Mockito.mock(MessageDigest.class);
+			Mockito.doReturn("adopted").when(cryptor).encryptFilename(BaseEncoding.base64Url(), newClearName, stepParentDir.dirId.getBytes(StandardCharsets.UTF_8));
+			var sha1 = Mockito.mock(MessageDigest.class);
 
-		result.adoptOrphanedResource(oldCipherPath, newClearName, stepParentDir, cryptor, "longNameSuffix", sha1);
+			result.adoptOrphanedResource(oldCipherPath, newClearName, stepParentDir, cryptor, "longNameSuffix", sha1);
 
-		Assertions.assertEquals(expectedMsg, Files.readString(stepParentDir.path.resolve("adopted.c9r")));
-		Assertions.assertTrue(Files.notExists(oldCipherPath));
-	}
-
-
-	@Test
-	@DisplayName("adoptOrphanedResource runs for shortened resource with existing name.c9s")
-	public void testAdoptOrphanedShortened() throws IOException {
-		Path oldCipherPath = cipherOrphan.resolve("orphan.c9s");
-		String newClearName = "JimKnopf";
-		Files.createDirectories(oldCipherPath);
-		Files.createFile(oldCipherPath.resolve("name.c9s"));
-
-		CryptoPathMapper.CiphertextDirectory stepParentDir = new CryptoPathMapper.CiphertextDirectory("aaaaaa", pathToVault.resolve("d/22/2222"));
-		Files.createDirectories(stepParentDir.path);
-
-		Mockito.doReturn("adopted").when(cryptor).encryptFilename(Mockito.any(), Mockito.any(), Mockito.any());
-		try (var baseEncodingClass = Mockito.mockStatic(BaseEncoding.class)) {
-			MessageDigest sha1 = Mockito.mock(MessageDigest.class);
-			Mockito.doReturn(new byte[]{}).when(sha1).digest(Mockito.any());
-
-			BaseEncoding base64url = Mockito.mock(BaseEncoding.class);
-			baseEncodingClass.when(() -> BaseEncoding.base64Url()).thenReturn(base64url);
-			Mockito.doReturn("adopted_shortened").when(base64url).encode(Mockito.any());
-
-			result.adoptOrphanedResource(oldCipherPath, newClearName, stepParentDir, cryptor, "", sha1);
+			Assertions.assertEquals(expectedMsg, Files.readString(stepParentDir.path.resolve("adopted.c9r")));
+			Assertions.assertTrue(Files.notExists(oldCipherPath));
 		}
 
-		Assertions.assertTrue(Files.exists(stepParentDir.path.resolve("adopted_shortened.c9s")));
-		Assertions.assertEquals("adopted.c9r", Files.readString(stepParentDir.path.resolve("adopted_shortened.c9s/name.c9s")));
-		Assertions.assertTrue(Files.notExists(oldCipherPath));
-	}
 
+		@Test
+		@DisplayName("adoptOrphanedResource runs for shortened resource with existing name.c9s")
+		public void testAdoptOrphanedShortened() throws IOException {
+			Path oldCipherPath = cipherOrphan.resolve("orphan.c9s");
+			String newClearName = "JimKnopf";
+			Files.createDirectories(oldCipherPath);
+			Files.createFile(oldCipherPath.resolve("name.c9s"));
 
-	@Test
-	@DisplayName("adoptOrphanedResource runs for shortened resource without existing name.c9s")
-	public void testAdoptOrphanedShortenedMissingNameC9s() throws IOException {
-		Path oldCipherPath = cipherOrphan.resolve("orphan.c9s");
-		String newClearName = "TomSawyer";
-		Files.createDirectories(oldCipherPath);
+			CryptoPathMapper.CiphertextDirectory stepParentDir = new CryptoPathMapper.CiphertextDirectory("aaaaaa", pathToVault.resolve("d/22/2222"));
+			Files.createDirectories(stepParentDir.path);
 
-		CryptoPathMapper.CiphertextDirectory stepParentDir = new CryptoPathMapper.CiphertextDirectory("aaaaaa", pathToVault.resolve("d/22/2222"));
-		Files.createDirectories(stepParentDir.path);
+			Mockito.doReturn("adopted").when(cryptor).encryptFilename(Mockito.any(), Mockito.any(), Mockito.any());
+			try (var baseEncodingClass = Mockito.mockStatic(BaseEncoding.class)) {
+				MessageDigest sha1 = Mockito.mock(MessageDigest.class);
+				Mockito.doReturn(new byte[]{}).when(sha1).digest(Mockito.any());
 
-		Mockito.doReturn("adopted").when(cryptor).encryptFilename(Mockito.any(), Mockito.any(), Mockito.any());
-		try (var baseEncodingClass = Mockito.mockStatic(BaseEncoding.class)) {
-			MessageDigest sha1 = Mockito.mock(MessageDigest.class);
-			Mockito.doReturn(new byte[]{}).when(sha1).digest(Mockito.any());
+				BaseEncoding base64url = Mockito.mock(BaseEncoding.class);
+				baseEncodingClass.when(() -> BaseEncoding.base64Url()).thenReturn(base64url);
+				Mockito.doReturn("adopted_shortened").when(base64url).encode(Mockito.any());
 
-			BaseEncoding base64url = Mockito.mock(BaseEncoding.class);
-			baseEncodingClass.when(() -> BaseEncoding.base64Url()).thenReturn(base64url);
-			Mockito.doReturn("adopted_shortened").when(base64url).encode(Mockito.any());
+				result.adoptOrphanedResource(oldCipherPath, newClearName, stepParentDir, cryptor, "", sha1);
+			}
 
-			result.adoptOrphanedResource(oldCipherPath, newClearName, stepParentDir, cryptor, "", sha1);
+			Assertions.assertTrue(Files.exists(stepParentDir.path.resolve("adopted_shortened.c9s")));
+			Assertions.assertEquals("adopted.c9r", Files.readString(stepParentDir.path.resolve("adopted_shortened.c9s/name.c9s")));
+			Assertions.assertTrue(Files.notExists(oldCipherPath));
 		}
 
-		Assertions.assertTrue(Files.exists(stepParentDir.path.resolve("adopted_shortened.c9s")));
-		Assertions.assertEquals("adopted.c9r", Files.readString(stepParentDir.path.resolve("adopted_shortened.c9s/name.c9s")));
-		Assertions.assertTrue(Files.notExists(oldCipherPath));
+
+		@Test
+		@DisplayName("adoptOrphanedResource runs for shortened resource without existing name.c9s")
+		public void testAdoptOrphanedShortenedMissingNameC9s() throws IOException {
+			Path oldCipherPath = cipherOrphan.resolve("orphan.c9s");
+			String newClearName = "TomSawyer";
+			Files.createDirectories(oldCipherPath);
+
+			CryptoPathMapper.CiphertextDirectory stepParentDir = new CryptoPathMapper.CiphertextDirectory("aaaaaa", pathToVault.resolve("d/22/2222"));
+			Files.createDirectories(stepParentDir.path);
+
+			Mockito.doReturn("adopted").when(cryptor).encryptFilename(Mockito.any(), Mockito.any(), Mockito.any());
+			try (var baseEncodingClass = Mockito.mockStatic(BaseEncoding.class)) {
+				MessageDigest sha1 = Mockito.mock(MessageDigest.class);
+				Mockito.doReturn(new byte[]{}).when(sha1).digest(Mockito.any());
+
+				BaseEncoding base64url = Mockito.mock(BaseEncoding.class);
+				baseEncodingClass.when(() -> BaseEncoding.base64Url()).thenReturn(base64url);
+				Mockito.doReturn("adopted_shortened").when(base64url).encode(Mockito.any());
+
+				result.adoptOrphanedResource(oldCipherPath, newClearName, stepParentDir, cryptor, "", sha1);
+			}
+
+			Assertions.assertTrue(Files.exists(stepParentDir.path.resolve("adopted_shortened.c9s")));
+			Assertions.assertEquals("adopted.c9r", Files.readString(stepParentDir.path.resolve("adopted_shortened.c9s/name.c9s")));
+			Assertions.assertTrue(Files.notExists(oldCipherPath));
+		}
+
 	}
 
 

--- a/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
@@ -1,0 +1,89 @@
+package org.cryptomator.cryptofs.health.dirid;
+
+import com.google.common.io.BaseEncoding;
+import jdk.jfr.Name;
+import org.cryptomator.cryptofs.common.Constants;
+import org.cryptomator.cryptolib.api.FileNameCryptor;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+import javax.inject.Named;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.UUID;
+
+public class OrphanDirTest {
+
+	@TempDir
+	public Path pathToVault;
+
+	@Test
+	public void testPrepareCryptoFileSystemNonExistingRecoveryDir() throws IOException {
+		Path p = Mockito.mock(Path.class, "ignored");
+		OrphanDir result = new OrphanDir(p);
+
+
+		Path cipherRootDir = pathToVault.resolve("d/00/0000");
+		Files.createDirectories(cipherRootDir);
+		String clearStepParentName = "step-parent";
+		FileNameCryptor cryptor = Mockito.mock(FileNameCryptor.class);
+		Mockito.doReturn("000000").when(cryptor).hashDirectoryId(Constants.ROOT_DIR_ID);
+		Mockito.doReturn("111111").when(cryptor).hashDirectoryId(Constants.RECOVERY_DIR_ID);
+		Mockito.doReturn("222222").when(cryptor).hashDirectoryId("aaaaaa");
+
+		Mockito.doReturn("1").when(cryptor).encryptFilename(BaseEncoding.base64Url(), Constants.RECOVERY_DIR_NAME, Constants.ROOT_DIR_ID.getBytes(StandardCharsets.UTF_8));
+		Mockito.doReturn("2").when(cryptor).encryptFilename(BaseEncoding.base64Url(), clearStepParentName, Constants.RECOVERY_DIR_ID.getBytes(StandardCharsets.UTF_8));
+
+		try (var uuidClass = Mockito.mockStatic(UUID.class)) {
+			UUID uuid = Mockito.mock(UUID.class);
+			uuidClass.when(() -> UUID.randomUUID()).thenReturn(uuid);
+			Mockito.doReturn("aaaaaa").when(uuid).toString();
+
+			result.prepareCryptoFilesystem(pathToVault, cryptor, clearStepParentName);
+		}
+
+		Assertions.assertEquals(Constants.RECOVERY_DIR_ID, Files.readString(pathToVault.resolve("d/00/0000/1.c9r/dir.c9r"), StandardCharsets.UTF_8));
+		Assertions.assertEquals("aaaaaa", Files.readString(pathToVault.resolve("d/11/1111/2.c9r/dir.c9r"), StandardCharsets.UTF_8));
+		Assertions.assertTrue(Files.isDirectory(pathToVault.resolve("d/22/2222")));
+
+	}
+
+	@Test
+	@Name("test prepare fs method with a user created recovery id")
+	public void testPrepareCryptoFSWithRecoveryDirWrongId() throws IOException {
+		Path p = Mockito.mock(Path.class, "ignored");
+		OrphanDir result = new OrphanDir(p);
+
+		Path userCreatedRecoveryDirFile = pathToVault.resolve("d/00/0000/1.c9r/dir.c9r");
+		Files.createDirectories(userCreatedRecoveryDirFile.getParent());
+		Files.writeString(userCreatedRecoveryDirFile,UUID.randomUUID().toString(),StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
+
+		String clearStepParentName = "step-parent";
+		FileNameCryptor cryptor = Mockito.mock(FileNameCryptor.class);
+		Mockito.doReturn("000000").when(cryptor).hashDirectoryId(Constants.ROOT_DIR_ID);
+		Mockito.doReturn("111111").when(cryptor).hashDirectoryId(Constants.RECOVERY_DIR_ID);
+		Mockito.doReturn("222222").when(cryptor).hashDirectoryId("aaaaaa");
+
+		Mockito.doReturn("1").when(cryptor).encryptFilename(BaseEncoding.base64Url(), Constants.RECOVERY_DIR_NAME, Constants.ROOT_DIR_ID.getBytes(StandardCharsets.UTF_8));
+		Mockito.doReturn("2").when(cryptor).encryptFilename(BaseEncoding.base64Url(), clearStepParentName, Constants.RECOVERY_DIR_ID.getBytes(StandardCharsets.UTF_8));
+
+		try (var uuidClass = Mockito.mockStatic(UUID.class)) {
+			UUID uuid = Mockito.mock(UUID.class);
+			uuidClass.when(() -> UUID.randomUUID()).thenReturn(uuid);
+			Mockito.doReturn("aaaaaa").when(uuid).toString();
+
+			Assertions.assertThrows(FileAlreadyExistsException.class, () -> result.prepareCryptoFilesystem(pathToVault, cryptor, clearStepParentName));
+		}
+
+		Assertions.assertNotEquals(Constants.RECOVERY_DIR_ID, Files.readString(pathToVault.resolve("d/00/0000/1.c9r/dir.c9r"), StandardCharsets.UTF_8));
+		Assertions.assertTrue(Files.notExists(pathToVault.resolve("d/11/1111/2.c9r/dir.c9r")));
+		Assertions.assertTrue(Files.notExists(pathToVault.resolve("d/22/2222")));
+
+	}
+}


### PR DESCRIPTION
This PR implements the `OrphanDir::fix` method.

The fix is implemented in a way that it restricts itself only to fixing the orphan dir problem. Other problems like a missing or too big `dir.c9r` are ignored. Hence, the fix must preserve the shortend property of a ciphertext file.

To get an understanding, consider an orphaned ciphertext dir with a shortened file, where `content.c9r` is missing:
```
-d/NC/RWII6WWFYQTWWEMBXK4OOLUMUHT6PX
    |- 7HkyoIUdCinG8NxXbwD5hD6nNsE=.c9s
        |- name.c9s
        // missing content.c9s
```

Since the content.c9s is missing, the file cannot be simply unshortend. By keeping the file shortened, it is ensured that the orphaned directory can be integrated into the vault structure without stopping at these errors.

All files inside the orphaned directory will be moved to a directory with the cleartext path `/CRYPTOMATOR_RECOVERY/[DirId-Hash of Orphan]`. The name of the "deorphaned"  dir is deterministic, such that after an interrupted fix, a new result will continue placing all orphan files into the same deorphaned directory.
To prevent `FileAlreadyExistsExceptions`, each moved resource in the same run is suffixed with a runId.


`/CRYPTOMATOR_RECOVERY` is a new directory with a unique dir id. All "deorphaned" directories will be located their. It is only created on demand by the fix() method. From the user perspective it will be a normal directory. If a user creates in the vault content root a directory with this name, it won't have the unique id. Every orphanDir fix will fail and the solution is to rename the user generated dir. This can be implemetned as an additonal check or result. If the recovery dir is orphaned itself, just the missing c9r-directory and dirId-file are created and not files moved. An orphaned, user created directory with the same name will stay orphaned and is handled via standard deorphan procedure.

In this context, the Health API is adjusted, that  `fix(...)` throws an IOException-