### PR TITLE
Health API / Directory Check: Result EmptyDirFile

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/DirIdCheck.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/DirIdCheck.java
@@ -103,6 +103,9 @@ public class DirIdCheck implements HealthCheck {
 			if (attrs.size() > Constants.MAX_DIR_FILE_LENGTH) {
 				LOG.warn("Encountered dir.c9r file of size {}", attrs.size());
 				resultCollector.accept(new ObeseDirFile(file, attrs.size()));
+			} else if (attrs.size() == 0) {
+				LOG.warn("Empty dir.c9r file.", file);
+				resultCollector.accept(new EmptyDirFile(file));
 			} else {
 				byte[] bytes = Files.readAllBytes(file);
 				String dirId = new String(bytes, StandardCharsets.UTF_8);

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/EmptyDirFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/EmptyDirFile.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import static org.cryptomator.cryptofs.health.api.CommonDetailKeys.DIR_ID_FILE;
 
 /**
- * A critical diagnostic result of an empty directory id file (dir.c9r).
+ * A diagnostic result of an empty directory id file (dir.c9r).
  * <p>
  * Even though the empty directory ID exists, it is reserved for the root node of the crypto filesystem only.
  * Due to its nature, the root node has no corresponding dir.c9r file.

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/EmptyDirFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/EmptyDirFile.java
@@ -1,17 +1,21 @@
 package org.cryptomator.cryptofs.health.dirid;
 
-import org.cryptomator.cryptofs.VaultConfig;
 import org.cryptomator.cryptofs.health.api.DiagnosticResult;
-import org.cryptomator.cryptolib.api.Cryptor;
-import org.cryptomator.cryptolib.api.Masterkey;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
 import static org.cryptomator.cryptofs.health.api.CommonDetailKeys.DIR_ID_FILE;
 
+/**
+ * A critical diagnostic result of an empty directory id file (dir.c9r).
+ * <p>
+ * Even thou the empty directory ID exists, it is reserved for the root node of the crypto filesystem only.
+ * DUe to its nature, the root node has no corresponding dir.c9r file.
+ * As a consequence, actual dir.c9r files must not be empty, otherwise it is an error in the vault structure.
+ *
+ * @see org.cryptomator.cryptofs.common.Constants#ROOT_DIR_ID
+ */
 public class EmptyDirFile implements DiagnosticResult {
 
 	final Path dirFile;

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/EmptyDirFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/EmptyDirFile.java
@@ -1,0 +1,45 @@
+package org.cryptomator.cryptofs.health.dirid;
+
+import org.cryptomator.cryptofs.VaultConfig;
+import org.cryptomator.cryptofs.health.api.DiagnosticResult;
+import org.cryptomator.cryptolib.api.Cryptor;
+import org.cryptomator.cryptolib.api.Masterkey;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.cryptomator.cryptofs.health.api.CommonDetailKeys.DIR_ID_FILE;
+
+public class EmptyDirFile implements DiagnosticResult {
+
+	final Path dirFile;
+
+	public EmptyDirFile(Path dirFile) {this.dirFile = dirFile;}
+
+	@Override
+	public Severity getSeverity() {
+		return Severity.CRITICAL;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("File %s is empty, expected content", dirFile);
+	}
+
+	/*
+	TODO: remove dirFile and parent dir, Change severity to WARN
+	@Override
+	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
+		Files.delete(dirFile);
+		Files.delete(dirFile.getParent());
+
+	}
+	 */
+
+	@Override
+	public Map<String, String> details() {
+		return Map.of(DIR_ID_FILE, dirFile.toString());
+	}
+}

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/EmptyDirFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/EmptyDirFile.java
@@ -10,8 +10,8 @@ import static org.cryptomator.cryptofs.health.api.CommonDetailKeys.DIR_ID_FILE;
 /**
  * A critical diagnostic result of an empty directory id file (dir.c9r).
  * <p>
- * Even thou the empty directory ID exists, it is reserved for the root node of the crypto filesystem only.
- * DUe to its nature, the root node has no corresponding dir.c9r file.
+ * Even though the empty directory ID exists, it is reserved for the root node of the crypto filesystem only.
+ * Due to its nature, the root node has no corresponding dir.c9r file.
  * As a consequence, actual dir.c9r files must not be empty, otherwise it is an error in the vault structure.
  *
  * @see org.cryptomator.cryptofs.common.Constants#ROOT_DIR_ID

--- a/src/test/java/org/cryptomator/cryptofs/health/dirid/DirIdCheckTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/dirid/DirIdCheckTest.java
@@ -37,7 +37,7 @@ public class DirIdCheckTest {
 			AA/aaaa/baz=.c9r/symlink.c9r = linktarget
 			BB/bbbb/foo=.c9r/dir.c9r = CCcccc
 			BB/bbbb/bar=.c9r/dir.c9r = ffffffffffff-aaaaaaaaaaaa-tttttttttttt
-			BB/bbbb/baz=.c9r/dir.c9r = EMPTY
+			BB/bbbb/baz=.c9r/dir.c9r = [EMPTY]
 			BB/bbbb/foo=.c9r/unrelated/dir.c9r = unrelatedfile
 			CC/cccc/foo=.c9r = file
 			""";
@@ -143,7 +143,7 @@ public class DirIdCheckTest {
 				var file = line.substring(0, sep);
 				var contents = line.substring(sep + 3);
 				Files.createDirectories(root.resolve(file).getParent());
-				if (!contents.equals("EMPTY")) {
+				if (!contents.equals("[EMPTY]")) {
 					Files.writeString(root.resolve(file), contents, StandardCharsets.US_ASCII, StandardOpenOption.CREATE_NEW);
 				} else {
 					Files.createFile(root.resolve(file));

--- a/src/test/java/org/cryptomator/cryptofs/health/dirid/DirIdCheckTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/dirid/DirIdCheckTest.java
@@ -10,7 +10,6 @@ import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -140,13 +139,12 @@ public class DirIdCheckTest {
 		try {
 			if (line.contains(" = ")) {
 				var sep = line.indexOf(" = ");
-				var file = line.substring(0, sep);
+				var file = root.resolve(line.substring(0, sep));
 				var contents = line.substring(sep + 3);
-				Files.createDirectories(root.resolve(file).getParent());
+				Files.createDirectories(file.getParent());
+				Files.createFile(file);
 				if (!contents.equals("[EMPTY]")) {
-					Files.writeString(root.resolve(file), contents, StandardCharsets.US_ASCII, StandardOpenOption.CREATE_NEW);
-				} else {
-					Files.createFile(root.resolve(file));
+					Files.writeString(file, contents, StandardCharsets.US_ASCII, StandardOpenOption.WRITE);
 				}
 			} else {
 				Files.createDirectories(root.resolve(line));

--- a/src/test/java/org/cryptomator/cryptofs/health/dirid/DirIdCheckTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/dirid/DirIdCheckTest.java
@@ -142,9 +142,11 @@ public class DirIdCheckTest {
 				var file = root.resolve(line.substring(0, sep));
 				var contents = line.substring(sep + 3);
 				Files.createDirectories(file.getParent());
-				Files.createFile(file);
-				if (!contents.equals("[EMPTY]")) {
-					Files.writeString(file, contents, StandardCharsets.US_ASCII, StandardOpenOption.WRITE);
+				if (contents.equals("[EMPTY]")) {
+					Files.createFile(file);
+				} else {
+					Files.writeString(file, contents, StandardCharsets.US_ASCII, StandardOpenOption.CREATE_NEW);
+
 				}
 			} else {
 				Files.createDirectories(root.resolve(line));


### PR DESCRIPTION
This PR adds to the Directory Check the `EmptyDirFileResult`.

It indicates, that a dir.c9r file exists, but it is empty.

The suggested, but yet not implemented fix is to remove this dir file and its parent, such that the name is not blocked in this directory without any apparent reason for the user.

