### PR TITLE
Feature/shortened names check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,8 +143,10 @@
 				<version>3.0.0-M5</version>
 				<configuration>
 					<!-- Allow reflection for Mockito, so it can properly mock non-public classes -->
-					<argLine>--add-opens=org.cryptomator.cryptofs/org.cryptomator.cryptofs.health.dirid=ALL-UNNAMED --add-opens=org.cryptomator.cryptofs/org.cryptomator.cryptofs.health.type=ALL-UNNAMED</argLine>
-				</configuration>
+					<argLine>--add-opens=org.cryptomator.cryptofs/org.cryptomator.cryptofs.health.dirid=ALL-UNNAMED
+						--add-opens=org.cryptomator.cryptofs/org.cryptomator.cryptofs.health.type=ALL-UNNAMED
+						--add-opens=org.cryptomator.cryptofs/org.cryptomator.cryptofs.health.shortened=ALL-UNNAMED</argLine>
+			</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -2,6 +2,7 @@ import org.cryptomator.cryptofs.CryptoFileSystemProvider;
 import org.cryptomator.cryptofs.common.CiphertextFileType;
 import org.cryptomator.cryptofs.health.api.HealthCheck;
 import org.cryptomator.cryptofs.health.dirid.DirIdCheck;
+import org.cryptomator.cryptofs.health.shortened.ShortenedNamesCheck;
 import org.cryptomator.cryptofs.health.type.CiphertextFileTypeCheck;
 
 import java.nio.file.spi.FileSystemProvider;
@@ -27,6 +28,6 @@ module org.cryptomator.cryptofs {
 
 	uses HealthCheck;
 
-	provides HealthCheck with DirIdCheck, CiphertextFileTypeCheck;
+	provides HealthCheck with DirIdCheck, CiphertextFileTypeCheck, ShortenedNamesCheck;
 	provides FileSystemProvider with CryptoFileSystemProvider;
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/LongShortNamesMismatch.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/LongShortNamesMismatch.java
@@ -1,0 +1,40 @@
+package org.cryptomator.cryptofs.health.shortened;
+
+import org.cryptomator.cryptofs.VaultConfig;
+import org.cryptomator.cryptofs.health.api.DiagnosticResult;
+import org.cryptomator.cryptolib.api.Cryptor;
+import org.cryptomator.cryptolib.api.Masterkey;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * TODO: doc doc doc
+ * 			- the duckumentation duck
+ *		   __
+ *	   ___( o)>
+ *	   \ <_. )
+ *		`---'   hjw
+ */
+public class LongShortNamesMismatch implements DiagnosticResult {
+
+	final Path c9sDir;
+
+	public LongShortNamesMismatch(Path c9sDir) {this.c9sDir = c9sDir;}
+
+	@Override
+	public Severity getSeverity() {
+		return Severity.WARN;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("TODO %s",c9sDir); //TODO
+	}
+
+	@Override
+	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
+		//TODO: security implications
+	}
+
+}

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/LongShortNamesMismatch.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/LongShortNamesMismatch.java
@@ -9,18 +9,17 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 /**
- * TODO: doc doc doc
- * 			- the duckumentation duck
- *		   __
- *	   ___( o)>
- *	   \ <_. )
- *		`---'   hjw
+ * A c9s directory where the name of the directory is not a Base64URL encoded SHA1-hash of the contents in {@Value org.cryptomator.cryptofs.Constants#INFLATED_FILE_NAME}
  */
 public class LongShortNamesMismatch implements DiagnosticResult {
 
 	final Path c9sDir;
+	final String encryptedLongName;
 
-	public LongShortNamesMismatch(Path c9sDir) {this.c9sDir = c9sDir;}
+	public LongShortNamesMismatch(Path c9sDir, String encryptedLongName) {
+		this.c9sDir = c9sDir;
+		this.encryptedLongName = encryptedLongName;
+	}
 
 	@Override
 	public Severity getSeverity() {
@@ -29,12 +28,12 @@ public class LongShortNamesMismatch implements DiagnosticResult {
 
 	@Override
 	public String toString() {
-		return String.format("TODO %s",c9sDir); //TODO
+		return String.format("Filename of %s is not a base64url encoded SHA1 hash of %s.", c9sDir, encryptedLongName);
 	}
 
 	@Override
 	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
-		//TODO: security implications
+		//TODO: discuss security implications
 	}
 
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/LongShortNamesMismatch.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/LongShortNamesMismatch.java
@@ -10,7 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
- * A c9s directory where the name of the directory is not a Base64URL encoded SHA1-hash of the contents in {@Value org.cryptomator.cryptofs.Constants#INFLATED_FILE_NAME}
+ * A c9s directory where the name of the directory is not a Base64URL encoded SHA1-hash of the contents in {@value org.cryptomator.cryptofs.common.Constants#INFLATED_FILE_NAME}
  */
 public class LongShortNamesMismatch implements DiagnosticResult {
 

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/LongShortNamesMismatch.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/LongShortNamesMismatch.java
@@ -33,7 +33,6 @@ public class LongShortNamesMismatch implements DiagnosticResult {
 	}
 
 	// fix by renaming the parent to the content of name.c9s
-	// TODO: once dirId is present, on AlreadyExistsException reattempt move with suffixed name
 	@Override
 	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
 		Files.move(c9sDir, c9sDir.resolveSibling(expectedShortName));

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/LongShortNamesMismatch.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/LongShortNamesMismatch.java
@@ -6,6 +6,7 @@ import org.cryptomator.cryptolib.api.Cryptor;
 import org.cryptomator.cryptolib.api.Masterkey;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
@@ -14,11 +15,11 @@ import java.nio.file.Path;
 public class LongShortNamesMismatch implements DiagnosticResult {
 
 	final Path c9sDir;
-	final String encryptedLongName;
+	final String expectedShortName;
 
-	public LongShortNamesMismatch(Path c9sDir, String encryptedLongName) {
+	public LongShortNamesMismatch(Path c9sDir, String expectedShortName) {
 		this.c9sDir = c9sDir;
-		this.encryptedLongName = encryptedLongName;
+		this.expectedShortName = expectedShortName;
 	}
 
 	@Override
@@ -28,12 +29,14 @@ public class LongShortNamesMismatch implements DiagnosticResult {
 
 	@Override
 	public String toString() {
-		return String.format("Filename of %s is not a base64url encoded SHA1 hash of %s.", c9sDir, encryptedLongName);
+		return String.format("Name of %s is not a base64url encoded SHA1 hash of String inside name.c9s.", c9sDir);
 	}
 
+	// fix by renaming the parent to the content of name.c9s
+	// TODO: once dirId is present, on AlreadyExistsException reattempt move with suffixed name
 	@Override
 	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
-		//TODO: discuss security implications
+		Files.move(c9sDir, c9sDir.resolveSibling(expectedShortName));
 	}
 
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/MissingLongName.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/MissingLongName.java
@@ -1,0 +1,43 @@
+package org.cryptomator.cryptofs.health.shortened;
+
+import org.cryptomator.cryptofs.VaultConfig;
+import org.cryptomator.cryptofs.health.api.DiagnosticResult;
+import org.cryptomator.cryptolib.api.Cryptor;
+import org.cryptomator.cryptolib.api.Masterkey;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * TODO: doc doc doc
+ * 			- the duckumentation duck
+ *		   __
+ *	   ___( o)>
+ *	   \ <_. )
+ *		`---'   hjw
+ */
+public class MissingLongName implements DiagnosticResult {
+
+	final Path c9sDir;
+
+	public MissingLongName(Path c9sDir) {this.c9sDir = c9sDir;}
+
+	@Override
+	public Severity getSeverity() {
+		return Severity.CRITICAL;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("TODO {}",c9sDir); //TODO
+	}
+
+	/*
+		Fix: create new name. BUUUT: without dirId not possible
+	@Override
+	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
+		//TODO
+	}
+	 */
+
+}

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/MissingLongName.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/MissingLongName.java
@@ -12,7 +12,6 @@ import java.nio.file.Path;
  *   <ul>
  * <li> the file {@value org.cryptomator.cryptofs.common.Constants#INFLATED_FILE_NAME} does not exist</li>
  * <li> it is not a regular file</li>
- * <li> (TODO: it is not decryptable)</li>
  *   </ul>
  */
 public class MissingLongName implements DiagnosticResult {
@@ -30,13 +29,5 @@ public class MissingLongName implements DiagnosticResult {
 	public String toString() {
 		return String.format("Shortened resource %s either misses %s or the file has invalid content.", c9sDir, Constants.INFLATED_FILE_NAME); //TODO
 	}
-
-	/*
-		Fix: create new name. BUUUT: without dirId not possible
-	@Override
-	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
-		//TODO
-	}
-	 */
 
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/MissingLongName.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/MissingLongName.java
@@ -9,12 +9,11 @@ import java.nio.file.Path;
  * A c9s directory with a missing long name.
  * <p>
  * A long name is missing if either
- *     <ul>
- * 		<li> the file {@Value org.cryptomator.cryptofs.Constants#INFLATED_FILE_NAME} does not exist</li>
- * 		<li> it is not a regular file</li>
- * 		<li> (TODO: it is not decryptable)</li>
- *     </ul>
- * </p>
+ *   <ul>
+ * <li> the file {@value org.cryptomator.cryptofs.common.Constants#INFLATED_FILE_NAME} does not exist</li>
+ * <li> it is not a regular file</li>
+ * <li> (TODO: it is not decryptable)</li>
+ *   </ul>
  */
 public class MissingLongName implements DiagnosticResult {
 

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/MissingLongName.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/MissingLongName.java
@@ -27,7 +27,7 @@ public class MissingLongName implements DiagnosticResult {
 
 	@Override
 	public String toString() {
-		return String.format("Shortened resource %s either misses %s or the file has invalid content.", c9sDir, Constants.INFLATED_FILE_NAME); //TODO
+		return String.format("Shortened resource %s either misses %s or the file has invalid content.", c9sDir, Constants.INFLATED_FILE_NAME);
 	}
 
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/MissingLongName.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/MissingLongName.java
@@ -1,20 +1,20 @@
 package org.cryptomator.cryptofs.health.shortened;
 
-import org.cryptomator.cryptofs.VaultConfig;
+import org.cryptomator.cryptofs.common.Constants;
 import org.cryptomator.cryptofs.health.api.DiagnosticResult;
-import org.cryptomator.cryptolib.api.Cryptor;
-import org.cryptomator.cryptolib.api.Masterkey;
 
-import java.io.IOException;
 import java.nio.file.Path;
 
 /**
- * TODO: doc doc doc
- * 			- the duckumentation duck
- *		   __
- *	   ___( o)>
- *	   \ <_. )
- *		`---'   hjw
+ * A c9s directory with a missing long name.
+ * <p>
+ * A long name is missing if either
+ *     <ul>
+ * 		<li> the file {@Value org.cryptomator.cryptofs.Constants#INFLATED_FILE_NAME} does not exist</li>
+ * 		<li> it is not a regular file</li>
+ * 		<li> (TODO: it is not decryptable)</li>
+ *     </ul>
+ * </p>
  */
 public class MissingLongName implements DiagnosticResult {
 
@@ -29,7 +29,7 @@ public class MissingLongName implements DiagnosticResult {
 
 	@Override
 	public String toString() {
-		return String.format("TODO {}",c9sDir); //TODO
+		return String.format("Shortened resource %s either misses %s or the file has invalid content.", c9sDir, Constants.INFLATED_FILE_NAME); //TODO
 	}
 
 	/*

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/ObeseNameFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/ObeseNameFile.java
@@ -7,7 +7,7 @@ import org.cryptomator.cryptofs.health.api.DiagnosticResult;
 import java.nio.file.Path;
 
 /**
- * A shortend file name file which exceeds the maximum size of {@Value org.cryptomator.cryptofs.LongFileNameProvider#MAX_FILENAME_BUFFER_SIZE} bytes.
+ * A shortend file name file which exceeds the maximum size of {@value org.cryptomator.cryptofs.LongFileNameProvider#MAX_FILENAME_BUFFER_SIZE} bytes.
  */
 public class ObeseNameFile implements DiagnosticResult {
 

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/ObeseNameFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/ObeseNameFile.java
@@ -1,16 +1,13 @@
 package org.cryptomator.cryptofs.health.shortened;
 
+import org.cryptomator.cryptofs.LongFileNameProvider;
+import org.cryptomator.cryptofs.common.Constants;
 import org.cryptomator.cryptofs.health.api.DiagnosticResult;
 
 import java.nio.file.Path;
 
 /**
- * TODO: doc doc doc
- * 			- the duckumentation duck
- * 		   __
- * 	   ___( o)>
- * 	   \ <_. )
- * 		`---'   hjw
+ * A shortend file name file which exceeds the maximum size of {@Value org.cryptomator.cryptofs.LongFileNameProvider#MAX_FILENAME_BUFFER_SIZE} bytes.
  */
 public class ObeseNameFile implements DiagnosticResult {
 
@@ -29,7 +26,7 @@ public class ObeseNameFile implements DiagnosticResult {
 
 	@Override
 	public String toString() {
-		return String.format("TODO %s %d",nameFile, size); //TODO
+		return String.format("Long filename file %s with size %d exceeds limit of %d for this type.", nameFile, size, LongFileNameProvider.MAX_FILENAME_BUFFER_SIZE);
 	}
 
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/ObeseNameFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/ObeseNameFile.java
@@ -1,7 +1,6 @@
 package org.cryptomator.cryptofs.health.shortened;
 
 import org.cryptomator.cryptofs.LongFileNameProvider;
-import org.cryptomator.cryptofs.common.Constants;
 import org.cryptomator.cryptofs.health.api.DiagnosticResult;
 
 import java.nio.file.Path;

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/ObeseNameFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/ObeseNameFile.java
@@ -1,0 +1,35 @@
+package org.cryptomator.cryptofs.health.shortened;
+
+import org.cryptomator.cryptofs.health.api.DiagnosticResult;
+
+import java.nio.file.Path;
+
+/**
+ * TODO: doc doc doc
+ * 			- the duckumentation duck
+ * 		   __
+ * 	   ___( o)>
+ * 	   \ <_. )
+ * 		`---'   hjw
+ */
+public class ObeseNameFile implements DiagnosticResult {
+
+	final Path nameFile;
+	final long size;
+
+	public ObeseNameFile(Path nameFile, long size) {
+		this.nameFile = nameFile;
+		this.size = size;
+	}
+
+	@Override
+	public Severity getSeverity() {
+		return Severity.CRITICAL;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("TODO %s %d",nameFile, size); //TODO
+	}
+
+}

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/ShortenedNamesCheck.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/ShortenedNamesCheck.java
@@ -86,8 +86,10 @@ public class ShortenedNamesCheck implements HealthCheck {
 			try {
 				var longName = inflate(dir);
 				var shortName = deflate(longName);
-				if (!dir.getFileName().equals(shortName)) {
+				if (!dir.getFileName().toString().equals(shortName)) {
 					resultCollector.accept(new LongShortNamesMismatch(dir));
+				} else {
+					resultCollector.accept(new ValidShortenedFile(dir));
 				}
 				//TODO: check if content of longName is decryptable
 				// dirID is needed for that
@@ -115,7 +117,8 @@ public class ShortenedNamesCheck implements HealthCheck {
 			}
 		}
 
-		public String deflate(String longFileName) {
+		//visible for testing
+		String deflate(String longFileName) {
 			byte[] longFileNameBytes = longFileName.getBytes(UTF_8);
 			byte[] hash = MessageDigestSupplier.SHA1.get().digest(longFileNameBytes);
 			return BASE64URL.encode(hash) + DEFLATED_FILE_SUFFIX;

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/ShortenedNamesCheck.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/ShortenedNamesCheck.java
@@ -79,6 +79,8 @@ public class ShortenedNamesCheck implements HealthCheck {
 		}
 
 		// visible for testing
+		//TODO: check if content of longName is decryptable. If not, result is Missing (not Mismatch as right now)
+		// dirID is needed for that
 		void checkShortenedName(Path dir) throws IOException {
 			Path nameFile = dir.resolve(INFLATED_FILE_NAME);
 
@@ -98,14 +100,12 @@ public class ShortenedNamesCheck implements HealthCheck {
 			}
 
 			var longName = readLongName(nameFile);
-			var shortName = deflate(longName);
-			if (!dir.getFileName().toString().equals(shortName)) {
-				resultCollector.accept(new LongShortNamesMismatch(dir, longName));
+			var expectedShortName = deflate(longName);
+			if (!dir.getFileName().toString().equals(expectedShortName)) {
+				resultCollector.accept(new LongShortNamesMismatch(dir, expectedShortName));
 			} else {
 				resultCollector.accept(new ValidShortenedFile(dir));
 			}
-			//TODO: check if content of longName is decryptable
-			// dirID is needed for that
 		}
 
 		//copied from LongFileNameProvider

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/ShortenedNamesCheck.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/ShortenedNamesCheck.java
@@ -33,12 +33,7 @@ import static org.cryptomator.cryptofs.common.Constants.DEFLATED_FILE_SUFFIX;
 import static org.cryptomator.cryptofs.common.Constants.INFLATED_FILE_NAME;
 
 /**
- * TODO: doc doc doc
- * 			- the duckumentation duck
- * 		   __
- * 	   ___( o)>
- * 	   \ <_. )
- * 		`---'   hjw
+ * Visits all c9s directories and checks if they all are valid shortened resource according the Cryptomator vault specification.
  */
 public class ShortenedNamesCheck implements HealthCheck {
 
@@ -105,7 +100,7 @@ public class ShortenedNamesCheck implements HealthCheck {
 			var longName = readLongName(nameFile);
 			var shortName = deflate(longName);
 			if (!dir.getFileName().toString().equals(shortName)) {
-				resultCollector.accept(new LongShortNamesMismatch(dir));
+				resultCollector.accept(new LongShortNamesMismatch(dir, longName));
 			} else {
 				resultCollector.accept(new ValidShortenedFile(dir));
 			}

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/ShortenedNamesCheck.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/ShortenedNamesCheck.java
@@ -1,0 +1,90 @@
+package org.cryptomator.cryptofs.health.shortened;
+
+import com.google.common.io.BaseEncoding;
+import org.cryptomator.cryptofs.LongFileNameProvider;
+import org.cryptomator.cryptofs.VaultConfig;
+import org.cryptomator.cryptofs.common.Constants;
+import org.cryptomator.cryptofs.health.api.CheckFailed;
+import org.cryptomator.cryptofs.health.api.DiagnosticResult;
+import org.cryptomator.cryptofs.health.api.HealthCheck;
+import org.cryptomator.cryptolib.api.Cryptor;
+import org.cryptomator.cryptolib.api.Masterkey;
+import org.cryptomator.cryptolib.common.MessageDigestSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.cryptomator.cryptofs.common.Constants.DEFLATED_FILE_SUFFIX;
+import static org.cryptomator.cryptofs.common.Constants.INFLATED_FILE_NAME;
+
+/**
+ * TODO: doc doc doc
+ * 			- the duckumentation duck
+ *		   __
+ *	   ___( o)>
+ *	   \ <_. )
+ *		`---'   hjw
+ */
+public class ShortenedNamesCheck implements HealthCheck {
+
+	private static final Logger LOG = LoggerFactory.getLogger(ShortenedNamesCheck.class);
+	private static final int MAX_TRAVERSAL_DEPTH = 3;
+	private static final BaseEncoding BASE64URL = BaseEncoding.base64Url();
+
+	@Override
+	public String name() {
+		return "Shortened Names Check";
+	}
+
+	@Override
+	public void check(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor, Consumer<DiagnosticResult> resultCollector) {
+
+		// scan vault structure:
+		var dataDirPath = pathToVault.resolve(Constants.DATA_DIR_NAME);
+		var dirVisitor = new ShortenedNamesCheck.DirVisitor(resultCollector);
+		try {
+			Files.walkFileTree(dataDirPath, Set.of(), MAX_TRAVERSAL_DEPTH, dirVisitor);
+		} catch (IOException e) {
+			LOG.error("Traversal of data dir failed.", e);
+			resultCollector.accept(new CheckFailed("Traversal of data dir failed. See log for details."));
+		}
+	}
+
+	// visible for testing
+	static class DirVisitor extends SimpleFileVisitor<Path> {
+
+		private final Consumer<DiagnosticResult> resultCollector;
+
+		public DirVisitor(Consumer<DiagnosticResult> resultCollector) {
+			this.resultCollector = resultCollector;
+		}
+
+		@Override
+		public FileVisitResult visitFile(Path dir, BasicFileAttributes attrs) throws IOException {
+			var name = dir.getFileName().toString();
+			if (attrs.isDirectory() && name.endsWith(Constants.DEFLATED_FILE_SUFFIX)) {
+				checkShortenedName(dir);
+			}
+			return FileVisitResult.CONTINUE;
+		}
+
+		// visible for testing
+		void checkShortenedName(Path dir) throws IOException {
+		}
+
+	}
+
+}

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/ValidShortenedFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/ValidShortenedFile.java
@@ -5,12 +5,7 @@ import org.cryptomator.cryptofs.health.api.DiagnosticResult;
 import java.nio.file.Path;
 
 /**
- * TODO: doc doc doc
- * 			- the duckumentation duck
- *		   __
- *	   ___( o)>
- *	   \ <_. )
- *		`---'   hjw
+ * A valid shortened resource according to the Cryptomator vault specification.
  */
 public class ValidShortenedFile implements DiagnosticResult {
 
@@ -25,7 +20,7 @@ public class ValidShortenedFile implements DiagnosticResult {
 
 	@Override
 	public String toString() {
-		return String.format("TODO %s", c9sDir);
+		return String.format("Found valid shortened resource at %s.", c9sDir);
 	}
 
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/ValidShortenedFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/ValidShortenedFile.java
@@ -1,0 +1,31 @@
+package org.cryptomator.cryptofs.health.shortened;
+
+import org.cryptomator.cryptofs.health.api.DiagnosticResult;
+
+import java.nio.file.Path;
+
+/**
+ * TODO: doc doc doc
+ * 			- the duckumentation duck
+ *		   __
+ *	   ___( o)>
+ *	   \ <_. )
+ *		`---'   hjw
+ */
+public class ValidShortenedFile implements DiagnosticResult {
+
+	final Path c9sDir;
+
+	public ValidShortenedFile(Path c9sDir) {this.c9sDir = c9sDir;}
+
+	@Override
+	public Severity getSeverity() {
+		return Severity.GOOD;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("TODO %s", c9sDir);
+	}
+
+}

--- a/src/main/resources/META-INF/services/org.cryptomator.cryptofs.health.api.HealthCheck
+++ b/src/main/resources/META-INF/services/org.cryptomator.cryptofs.health.api.HealthCheck
@@ -1,2 +1,3 @@
 org.cryptomator.cryptofs.health.dirid.DirIdCheck
 org.cryptomator.cryptofs.health.type.CiphertextFileTypeCheck
+org.cryptomator.cryptofs.health.shortened.ShortenedNamesCheck

--- a/src/test/java/org/cryptomator/cryptofs/health/shortened/LongShortNamesMismatchTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/shortened/LongShortNamesMismatchTest.java
@@ -1,0 +1,50 @@
+package org.cryptomator.cryptofs.health.shortened;
+
+import org.cryptomator.cryptofs.VaultConfig;
+import org.cryptomator.cryptolib.api.Cryptor;
+import org.cryptomator.cryptolib.api.Masterkey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class LongShortNamesMismatchTest {
+
+	@TempDir
+	public Path pathToVault;
+
+	private LongShortNamesMismatch result;
+	private Path dataDir;
+	private Path cipherDir;
+
+	@BeforeEach
+	public void init() throws IOException {
+		dataDir = pathToVault.resolve("d");
+		cipherDir = dataDir.resolve("00/0000");
+		Files.createDirectories(cipherDir);
+	}
+
+	@Test
+	@DisplayName("a successful fix only renames the c9s directory")
+	public void testSuccessfulFixRenamesResource() throws IOException {
+		//prepare
+		Path c9sDir = cipherDir.resolve("foo==.c9s");
+		result = new LongShortNamesMismatch(c9sDir, "bar==.c9s");
+
+		Files.createDirectory(c9sDir);
+
+		//execute
+		result.fix(pathToVault, Mockito.mock(VaultConfig.class), Mockito.mock(Masterkey.class), Mockito.mock(Cryptor.class));
+
+		//evaluate
+		Path expectedC9sDir = c9sDir.resolveSibling("bar==.c9s");
+		Files.exists(expectedC9sDir);
+		Files.notExists(c9sDir);
+	}
+
+}

--- a/src/test/java/org/cryptomator/cryptofs/health/shortened/ShortenedNamesCheckTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/shortened/ShortenedNamesCheckTest.java
@@ -3,36 +3,34 @@ package org.cryptomator.cryptofs.health.shortened;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import org.cryptomator.cryptofs.health.api.DiagnosticResult;
-import org.cryptomator.cryptofs.health.dirid.DirIdCheck;
-import org.cryptomator.cryptolib.api.Cryptor;
-import org.cryptomator.cryptolib.api.FileNameCryptor;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Set;
 import java.util.function.Consumer;
 
 public class ShortenedNamesCheckTest {
 
 	private FileSystem fs;
-	private Cryptor cryptor;
-	private FileNameCryptor fileNameCryptor;
 	private Path dataRoot;
 
 	@BeforeEach
 	public void setup() {
 		fs = Jimfs.newFileSystem(Configuration.unix());
-		cryptor = Mockito.mock(Cryptor.class);
-		fileNameCryptor = Mockito.mock(FileNameCryptor.class);
 		dataRoot = fs.getPath("/d");
-
-		Mockito.when(cryptor.fileNameCryptor()).thenReturn(fileNameCryptor);
-		Mockito.when(fileNameCryptor.hashDirectoryId(Mockito.any())).then(i -> i.getArgument(0));
 	}
 
 	@AfterEach
@@ -53,5 +51,54 @@ public class ShortenedNamesCheckTest {
 			visitor = new ShortenedNamesCheck.DirVisitor(resultsCollector);
 		}
 
+		@Test
+		@DisplayName("dirs ending with c9s are visited and closer looked at")
+		public void testC9sDirsAreVisited() throws IOException {
+			Path p = dataRoot.resolve("AA/zzzz/bar=.c9s");
+			Files.createDirectories(p);
+
+			var visitorSpy = Mockito.spy(visitor);
+			Files.walkFileTree(dataRoot, Set.of(), 3, visitorSpy);
+
+			Mockito.verify(visitorSpy).visitFile(Mockito.eq(p), Mockito.any());
+			Mockito.verify(visitorSpy).checkShortenedName(p);
+		}
+
+		@Test
+		@DisplayName("dir with name.c9s and matching long/short names produces valid result")
+		public void testExistingNamesFileAndMatchingNamesProducesValidResult() throws IOException {
+			String longName = "veryLongButNotTooLongName";
+			Path dir = dataRoot.resolve("AA/zzzz/shortName.c9s");
+			Path nameFile = dir.resolve("name.c9s");
+			Files.createDirectories(dir);
+			Files.writeString(nameFile, longName, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+
+			var visitorSpy = Mockito.spy(visitor);
+			Mockito.doReturn("shortName.c9s").when(visitorSpy).deflate(longName);
+
+			visitorSpy.checkShortenedName(dir);
+			ArgumentCaptor<DiagnosticResult> resultCaptor = ArgumentCaptor.forClass(DiagnosticResult.class);
+			Mockito.verify(resultsCollector).accept(resultCaptor.capture());
+			MatcherAssert.assertThat(resultCaptor.getValue(), Matchers.instanceOf(ValidShortenedFile.class));
+
+		}
+
+		@Test
+		@DisplayName("dir with missing name.c9s produces missing result")
+		public void testMissingNamesFileProducesMissingResult() {
+
+		}
+
+		@Test
+		@DisplayName("dir with too big name.c9s produces obese result")
+		public void testTooBigNamesFileProducesObeseResult() {
+
+		}
+
+		@Test
+		@DisplayName("dir with mismatching long and short names produces mismatch result")
+		public void testMismatchingNamesProducesMismatchResult() {
+
+		}
 	}
 }

--- a/src/test/java/org/cryptomator/cryptofs/health/shortened/ShortenedNamesCheckTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/shortened/ShortenedNamesCheckTest.java
@@ -1,0 +1,57 @@
+package org.cryptomator.cryptofs.health.shortened;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import org.cryptomator.cryptofs.health.api.DiagnosticResult;
+import org.cryptomator.cryptofs.health.dirid.DirIdCheck;
+import org.cryptomator.cryptolib.api.Cryptor;
+import org.cryptomator.cryptolib.api.FileNameCryptor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+import java.util.function.Consumer;
+
+public class ShortenedNamesCheckTest {
+
+	private FileSystem fs;
+	private Cryptor cryptor;
+	private FileNameCryptor fileNameCryptor;
+	private Path dataRoot;
+
+	@BeforeEach
+	public void setup() {
+		fs = Jimfs.newFileSystem(Configuration.unix());
+		cryptor = Mockito.mock(Cryptor.class);
+		fileNameCryptor = Mockito.mock(FileNameCryptor.class);
+		dataRoot = fs.getPath("/d");
+
+		Mockito.when(cryptor.fileNameCryptor()).thenReturn(fileNameCryptor);
+		Mockito.when(fileNameCryptor.hashDirectoryId(Mockito.any())).then(i -> i.getArgument(0));
+	}
+
+	@AfterEach
+	public void teardown() throws IOException {
+		fs.close();
+	}
+
+	@Nested
+	@DisplayName("DirVisitor")
+	public class Visitor {
+
+		private Consumer<DiagnosticResult> resultsCollector;
+		private ShortenedNamesCheck.DirVisitor visitor;
+
+		@BeforeEach
+		public void setup() {
+			resultsCollector = Mockito.mock(Consumer.class);
+			visitor = new ShortenedNamesCheck.DirVisitor(resultsCollector);
+		}
+
+	}
+}


### PR DESCRIPTION
This PR adds a new check to the health check API: ShortenedNamesCheck

For all directories ending with `c9s` it checks, if the file `name.c9s` exists in its hashed & encoded content matches the directory name.

It produces 4 results:
* Valid shortened resource
* Obese result, if the size of `name.c9s` is bigger than a cryptofs internal limit
* Missing result, if `name.c9s` is not a regular file or it does not exist
* Mismatch result, if the directory name does not match the hashed & encoded content

For the future this check can be refinded by providing the directory id of the encrypted dir containing the shortened resource, but for this PR it is out of scope and only noted via inline comments.