### PR TITLE
Feature: Do not add nullbytes when persisting Long Filename

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/LongFileNameProvider.java
+++ b/src/main/java/org/cryptomator/cryptofs/LongFileNameProvider.java
@@ -113,7 +113,7 @@ public class LongFileNameProvider {
 		private void persistInternal() throws IOException {
 			Path longNameFile = c9sPath.resolve(INFLATED_FILE_NAME);
 			Files.createDirectories(c9sPath);
-			Files.write(longNameFile,UTF_8.encode(longName).array()); //WRITE, CREATE, TRUNCATE_EXISTING
+			Files.writeString(longNameFile, longName, UTF_8, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
 		}
 	}
 

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/NotDecodableLongName.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/NotDecodableLongName.java
@@ -1,6 +1,5 @@
 package org.cryptomator.cryptofs.health.shortened;
 
-import org.cryptomator.cryptofs.common.Constants;
 import org.cryptomator.cryptofs.health.api.CommonDetailKeys;
 import org.cryptomator.cryptofs.health.api.DiagnosticResult;
 
@@ -12,7 +11,7 @@ import java.util.Map;
  * <p>
  * A string is only correct if
  * <ul>
- *     <li> it ends with {@value Constants#CRYPTOMATOR_FILE_SUFFIX} and </li>
+ *     <li> it ends with {@value org.cryptomator.cryptofs.common.Constants#CRYPTOMATOR_FILE_SUFFIX} and </li>
  *     <li> excluding the aforementioned suffix, is base64url encoded</li>
  * </ul>
  * <p>

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/NotDecodableLongName.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/NotDecodableLongName.java
@@ -1,0 +1,33 @@
+package org.cryptomator.cryptofs.health.shortened;
+
+import org.cryptomator.cryptofs.health.api.CommonDetailKeys;
+import org.cryptomator.cryptofs.health.api.DiagnosticResult;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * A name.c9s file, which content is _not_ a base64url encoded string.
+ */
+public class NotDecodableLongName implements DiagnosticResult {
+
+	private final Path nameFile;
+	private final String longName;
+
+	public NotDecodableLongName(Path nameFile, String longName) {
+		this.nameFile = nameFile;
+		this.longName = longName;
+	}
+
+	@Override
+	public Severity getSeverity() {
+		return Severity.CRITICAL;
+	}
+
+
+	@Override
+	public Map<String, String> details() {
+		return Map.of(CommonDetailKeys.ENCRYPTED_PATH, nameFile.toString(), //
+				"Encrypted Long Name", longName);
+	}
+}

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/NotDecodableLongName.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/NotDecodableLongName.java
@@ -1,5 +1,6 @@
 package org.cryptomator.cryptofs.health.shortened;
 
+import org.cryptomator.cryptofs.common.Constants;
 import org.cryptomator.cryptofs.health.api.CommonDetailKeys;
 import org.cryptomator.cryptofs.health.api.DiagnosticResult;
 
@@ -7,7 +8,17 @@ import java.nio.file.Path;
 import java.util.Map;
 
 /**
- * A name.c9s file, which content is _not_ a base64url encoded string.
+ * A name.c9s file with a syntactical <em>incorrect</em> string.
+ * <p>
+ * A string is only correct if
+ * <ul>
+ *     <li> it ends with {@value Constants#CRYPTOMATOR_FILE_SUFFIX} and </li>
+ *     <li> excluding the aforementioned suffix, is base64url encoded</li>
+ * </ul>
+ * <p>
+ * A special case represents the diagnostic result {@link TrailingBytesInNameFile}.
+ *
+ * @see TrailingBytesInNameFile
  */
 public class NotDecodableLongName implements DiagnosticResult {
 
@@ -28,6 +39,6 @@ public class NotDecodableLongName implements DiagnosticResult {
 	@Override
 	public Map<String, String> details() {
 		return Map.of(CommonDetailKeys.ENCRYPTED_PATH, nameFile.toString(), //
-				"Encrypted Long Name", longName);
+				"Stored String", longName);
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/ShortenedNamesCheck.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/ShortenedNamesCheck.java
@@ -24,7 +24,6 @@ import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.regex.Pattern;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.cryptomator.cryptofs.common.Constants.DEFLATED_FILE_SUFFIX;
@@ -38,7 +37,6 @@ public class ShortenedNamesCheck implements HealthCheck {
 	private static final Logger LOG = LoggerFactory.getLogger(ShortenedNamesCheck.class);
 	private static final int MAX_TRAVERSAL_DEPTH = 3;
 	private static final BaseEncoding BASE64URL = BaseEncoding.base64Url();
-	private static final Pattern NULL_BYTES = Pattern.compile("\0+");
 
 	@Override
 	public String name() {
@@ -91,7 +89,7 @@ public class ShortenedNamesCheck implements HealthCheck {
 			if (!attrs.isRegularFile()) {
 				resultCollector.accept(new MissingLongName(dir));
 				return;
-			} else if (attrs.size() > LongFileNameProvider.MAX_FILENAME_BUFFER_SIZE) { //TODO: should be revised
+			} else if (attrs.size() > LongFileNameProvider.MAX_FILENAME_BUFFER_SIZE) {
 				resultCollector.accept(new ObeseNameFile(nameFile, attrs.size()));
 				return;
 			}
@@ -125,16 +123,16 @@ public class ShortenedNamesCheck implements HealthCheck {
 		 */
 		SyntaxResult checkSyntax(String toAnalyse) {
 			int posObligatoryC9rString = toAnalyse.indexOf(Constants.CRYPTOMATOR_FILE_SUFFIX);
-			if(posObligatoryC9rString == -1) {
+			if (posObligatoryC9rString == -1) {
 				return SyntaxResult.INVALID;
 			}
 
 			var encryptedFileName = toAnalyse.substring(0, posObligatoryC9rString);
-			if(!BASE64URL.canDecode(encryptedFileName)) {
+			if (!BASE64URL.canDecode(encryptedFileName)) {
 				return SyntaxResult.INVALID;
 			}
 
-			if (toAnalyse.substring(posObligatoryC9rString).length() > Constants.CRYPTOMATOR_FILE_SUFFIX.length() ) {
+			if (toAnalyse.substring(posObligatoryC9rString).length() > Constants.CRYPTOMATOR_FILE_SUFFIX.length()) {
 				return SyntaxResult.TRAILING_BYTES;
 			}
 

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/TrailingBytesInNameFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/TrailingBytesInNameFile.java
@@ -13,15 +13,17 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Map;
 
+import static org.cryptomator.cryptofs.common.Constants.CRYPTOMATOR_FILE_SUFFIX;
+
 /**
  * Result and fix for bug https://github.com/cryptomator/cryptofs/issues/121
  */
-public class TrailingNullBytesInNameFile implements DiagnosticResult {
+public class TrailingBytesInNameFile implements DiagnosticResult {
 
 	private final Path nameFile;
 	private final String longName;
 
-	public TrailingNullBytesInNameFile(Path nameFile, String longName) {
+	public TrailingBytesInNameFile(Path nameFile, String longName) {
 		this.nameFile = nameFile;
 		this.longName = longName;
 	}
@@ -33,7 +35,11 @@ public class TrailingNullBytesInNameFile implements DiagnosticResult {
 
 	@Override
 	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
-		Files.writeString(pathToVault.resolve(nameFile), longName.substring(0, longName.indexOf('\0')), StandardCharsets.UTF_8, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+		var startIndexTrailingBytes = longName.indexOf(CRYPTOMATOR_FILE_SUFFIX) + CRYPTOMATOR_FILE_SUFFIX.length();
+		Files.writeString(pathToVault.resolve(nameFile), //
+				longName.substring(0, startIndexTrailingBytes), //
+				StandardCharsets.UTF_8, //
+				StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
 	}
 
 	@Override

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/TrailingNullBytesInNameFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/TrailingNullBytesInNameFile.java
@@ -1,0 +1,44 @@
+package org.cryptomator.cryptofs.health.shortened;
+
+import org.cryptomator.cryptofs.VaultConfig;
+import org.cryptomator.cryptofs.health.api.CommonDetailKeys;
+import org.cryptomator.cryptofs.health.api.DiagnosticResult;
+import org.cryptomator.cryptolib.api.Cryptor;
+import org.cryptomator.cryptolib.api.Masterkey;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Map;
+
+/**
+ * Result and fix for bug https://github.com/cryptomator/cryptofs/issues/121
+ */
+public class TrailingNullBytesInNameFile implements DiagnosticResult {
+
+	private final Path nameFile;
+	private final String longName;
+
+	public TrailingNullBytesInNameFile(Path nameFile, String longName) {
+		this.nameFile = nameFile;
+		this.longName = longName;
+	}
+
+	@Override
+	public Severity getSeverity() {
+		return Severity.WARN;
+	}
+
+	@Override
+	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
+		Files.writeString(pathToVault.resolve(nameFile), longName.substring(0, longName.indexOf('\0')), StandardCharsets.UTF_8, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+	}
+
+	@Override
+	public Map<String, String> details() {
+		return Map.of(CommonDetailKeys.ENCRYPTED_PATH, nameFile.toString(), //
+				"Encrypted Long Name", longName);
+	}
+}

--- a/src/test/java/org/cryptomator/cryptofs/LongFileNameProviderTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/LongFileNameProviderTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -90,7 +91,7 @@ public class LongFileNameProviderTest {
 	}
 
 	@Test
-	public void testPerstistCachedFailsOnReadOnlyFileSystems(@TempDir Path tmpPath) {
+	public void testPersistCachedFailsOnReadOnlyFileSystems(@TempDir Path tmpPath) {
 		LongFileNameProvider prov = new LongFileNameProvider(readonlyFlag);
 
 		String orig = "longName";
@@ -101,6 +102,18 @@ public class LongFileNameProviderTest {
 		Assertions.assertThrows(ReadOnlyFileSystemException.class, () -> {
 			deflated.persist();
 		});
+	}
+
+	@Test
+	public void testPersistedStringEqualsLongName(@TempDir Path tmpPath) throws IOException {
+		LongFileNameProvider prov = new LongFileNameProvider(readonlyFlag);
+
+		String orig = "LongNameOf200Chars00_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000";
+		Path canonicalFileName = tmpPath.resolve(orig);
+		LongFileNameProvider.DeflatedFileName deflated = prov.deflate(canonicalFileName);
+
+		deflated.persist();
+		Assertions.assertEquals(Files.readString(deflated.c9sPath.resolve("name.c9s"), StandardCharsets.UTF_8),deflated.longName);
 	}
 
 }

--- a/src/test/java/org/cryptomator/cryptofs/health/shortened/ShortenedNamesCheckTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/shortened/ShortenedNamesCheckTest.java
@@ -133,5 +133,20 @@ public class ShortenedNamesCheckTest {
 			MatcherAssert.assertThat(resultCaptor.getValue(), Matchers.instanceOf(LongShortNamesMismatch.class));
 		}
 
+		@Test
+		@DisplayName("dir with non base64url content in name.c9s produces illegal encoding result")
+		public void testNonBase64URLCharsInNameFileProducesIllegalEncodingResult() throws IOException {
+			String longName = "Bug121\0\0\0\0";
+			Path dir = dataRoot.resolve("AA/zzzz/shortName.c9s");
+			Path nameFile = dir.resolve("name.c9s");
+			Files.createDirectories(dir);
+			Files.writeString(nameFile, longName, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+
+			visitor.checkShortenedName(dir);
+			ArgumentCaptor<DiagnosticResult> resultCaptor = ArgumentCaptor.forClass(DiagnosticResult.class);
+			Mockito.verify(resultsCollector).accept(resultCaptor.capture());
+			MatcherAssert.assertThat(resultCaptor.getValue(), Matchers.instanceOf(TrailingNullBytesInNameFile.class));
+		}
+
 	}
 }

--- a/src/test/java/org/cryptomator/cryptofs/health/shortened/TrailingNullBytesInNameFileTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/shortened/TrailingNullBytesInNameFileTest.java
@@ -1,0 +1,53 @@
+package org.cryptomator.cryptofs.health.shortened;
+
+import org.cryptomator.cryptofs.VaultConfig;
+import org.cryptomator.cryptolib.api.Cryptor;
+import org.cryptomator.cryptolib.api.Masterkey;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+public class TrailingNullBytesInNameFileTest {
+
+	@TempDir
+	public Path pathToVault;
+
+	private TrailingNullBytesInNameFile result;
+	private Path dataDir;
+	private Path cipherDir;
+
+	@BeforeEach
+	public void init() throws IOException {
+		dataDir = pathToVault.resolve("d");
+		cipherDir = dataDir.resolve("00/0000");
+		Files.createDirectories(cipherDir);
+	}
+
+	@Test
+	@DisplayName("Successful fix only removes trailing null bytes")
+	public void testSuccessfulFixRemovesTrailingNullBytes() throws IOException {
+		//prepare
+		Path c9sDir = cipherDir.resolve("foo==.c9s");
+		Path nameFile = c9sDir.resolve("name.c9s");
+		var longName = "bar==.c9r\0\0\0";
+		result = new TrailingNullBytesInNameFile(nameFile, longName );
+
+		Files.createDirectory(c9sDir);
+		Files.writeString(nameFile, longName, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+
+		//execute
+		result.fix(pathToVault, Mockito.mock(VaultConfig.class), Mockito.mock(Masterkey.class), Mockito.mock(Cryptor.class));
+
+		//evaluate
+		Assertions.assertTrue(Files.readString(nameFile,StandardCharsets.UTF_8).indexOf('\0') == -1);
+	}
+}

--- a/src/test/java/org/cryptomator/cryptofs/health/shortened/TrailingNullBytesInNameFileTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/shortened/TrailingNullBytesInNameFileTest.java
@@ -21,7 +21,7 @@ public class TrailingNullBytesInNameFileTest {
 	@TempDir
 	public Path pathToVault;
 
-	private TrailingNullBytesInNameFile result;
+	private TrailingBytesInNameFile result;
 	private Path dataDir;
 	private Path cipherDir;
 
@@ -39,7 +39,7 @@ public class TrailingNullBytesInNameFileTest {
 		Path c9sDir = cipherDir.resolve("foo==.c9s");
 		Path nameFile = c9sDir.resolve("name.c9s");
 		var longName = "bar==.c9r\0\0\0";
-		result = new TrailingNullBytesInNameFile(nameFile, longName );
+		result = new TrailingBytesInNameFile(nameFile, longName );
 
 		Files.createDirectory(c9sDir);
 		Files.writeString(nameFile, longName, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);

--- a/src/test/java/org/cryptomator/cryptofs/health/shortened/TrailingNullBytesInNameFileTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/shortened/TrailingNullBytesInNameFileTest.java
@@ -48,6 +48,6 @@ public class TrailingNullBytesInNameFileTest {
 		result.fix(pathToVault, Mockito.mock(VaultConfig.class), Mockito.mock(Masterkey.class), Mockito.mock(Cryptor.class));
 
 		//evaluate
-		Assertions.assertTrue(Files.readString(nameFile,StandardCharsets.UTF_8).indexOf('\0') == -1);
+		Assertions.assertEquals("bar==.c9r", Files.readString(nameFile,StandardCharsets.UTF_8));
 	}
 }


### PR DESCRIPTION
This closes #121.

It adds two additional results to the shortend health check:
* `NotDecodableLongName` if the long filename ist not base64url encoded
* `TrailingNullBytes` if the stored string in name.c9s is affected by issue #121