### PR TITLE
Use BufferPool for cleartext as well as ciphertext chunks

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/ch/CleartextFileChannel.java
+++ b/src/main/java/org/cryptomator/cryptofs/ch/CleartextFileChannel.java
@@ -5,7 +5,7 @@ import org.cryptomator.cryptofs.CryptoFileSystemStats;
 import org.cryptomator.cryptofs.EffectiveOpenOptions;
 import org.cryptomator.cryptofs.fh.ByteSource;
 import org.cryptomator.cryptofs.fh.ChunkCache;
-import org.cryptomator.cryptofs.fh.ChunkData;
+import org.cryptomator.cryptofs.fh.Chunk;
 import org.cryptomator.cryptofs.fh.ExceptionsDuringWrite;
 import org.cryptomator.cryptofs.fh.OpenFileModifiedDate;
 import org.cryptomator.cryptofs.fh.OpenFileSize;
@@ -151,18 +151,18 @@ public class CleartextFileChannel extends AbstractFileChannel {
 				ByteBuffer cleartextChunk = ByteBuffer.allocate(cleartextChunkSize); // TODO: use BufferPool
 				src.copyTo(cleartextChunk);
 				cleartextChunk.flip();
-				ChunkData chunkData = new ChunkData(cleartextChunk, true);
-				chunkCache.set(chunkIndex, chunkData);
+				Chunk chunk = new Chunk(cleartextChunk, true);
+				chunkCache.set(chunkIndex, chunk);
 			} else {
 				/*
 				 * TODO performance:
 				 * We don't actually need to read the current data into the cache.
 				 * It would suffice if store the written data and do reading when storing the chunk.
 				 */
-				ChunkData chunkData = chunkCache.get(chunkIndex);
-				chunkData.data().limit(Math.max(chunkData.data().limit(), offsetInChunk + len)); // increase limit (if needed)
-				src.copyTo(chunkData.data().duplicate().position(offsetInChunk)); // work on duplicate using correct offset
-				chunkData.dirty().set(true);
+				Chunk chunk = chunkCache.get(chunkIndex);
+				chunk.data().limit(Math.max(chunk.data().limit(), offsetInChunk + len)); // increase limit (if needed)
+				src.copyTo(chunk.data().duplicate().position(offsetInChunk)); // work on duplicate using correct offset
+				chunk.dirty().set(true);
 			}
 			written += len;
 		}

--- a/src/main/java/org/cryptomator/cryptofs/fh/BufferPool.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/BufferPool.java
@@ -1,0 +1,57 @@
+package org.cryptomator.cryptofs.fh;
+
+import org.cryptomator.cryptofs.CryptoFileSystemScoped;
+import org.cryptomator.cryptolib.api.Cryptor;
+
+import javax.inject.Inject;
+import java.lang.ref.WeakReference;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * A pool of ByteBuffers for cleartext and ciphertext chunks to avoid on-heap allocation.
+ */
+@CryptoFileSystemScoped
+public class BufferPool {
+
+	private final int ciphertextChunkSize;
+	private final int cleartextChunkSize;
+	private final Queue<WeakReference<ByteBuffer>> ciphertextBuffers = new ConcurrentLinkedQueue<>();
+	private final Queue<WeakReference<ByteBuffer>> cleartextBuffers = new ConcurrentLinkedQueue<>();
+
+	@Inject
+	public BufferPool(Cryptor cryptor) {
+		this.ciphertextChunkSize = cryptor.fileContentCryptor().ciphertextChunkSize();
+		this.cleartextChunkSize = cryptor.fileContentCryptor().cleartextChunkSize();
+	}
+
+	private Optional<ByteBuffer> dequeueFrom(Queue<WeakReference<ByteBuffer>> queue) {
+		WeakReference<ByteBuffer> ref;
+		while ((ref = queue.poll()) != null) {
+			ByteBuffer cached = ref.get();
+			if (cached != null) {
+				cached.clear();
+				return Optional.of(cached);
+			}
+		}
+		return Optional.empty();
+	}
+
+	public ByteBuffer getCiphertextBuffer() {
+		return dequeueFrom(ciphertextBuffers).orElseGet(() -> ByteBuffer.allocate(ciphertextChunkSize));
+	}
+
+	public ByteBuffer getCleartextBuffer() {
+		return dequeueFrom(cleartextBuffers).orElseGet(() -> ByteBuffer.allocate(cleartextChunkSize));
+	}
+
+	public void recycle(ByteBuffer buffer) {
+		if (buffer.capacity() == ciphertextChunkSize) {
+			ciphertextBuffers.add(new WeakReference<>(buffer));
+		} else if (buffer.capacity() == cleartextChunkSize) {
+			cleartextBuffers.add(new WeakReference<>(buffer));
+		}
+	}
+}

--- a/src/main/java/org/cryptomator/cryptofs/fh/Chunk.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/Chunk.java
@@ -23,9 +23,9 @@ import static java.lang.String.format;
  *     <li>When no longer used, the cleartext ByteBuffer may be recycled</li>
  * </ol>
  */
-public record ChunkData(ByteBuffer data, AtomicBoolean dirty) {
+public record Chunk(ByteBuffer data, AtomicBoolean dirty) {
 
-	public ChunkData(ByteBuffer data, boolean dirty) {
+	public Chunk(ByteBuffer data, boolean dirty) {
 		this(data, new AtomicBoolean(dirty));
 	}
 

--- a/src/main/java/org/cryptomator/cryptofs/fh/Chunk.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/Chunk.java
@@ -33,9 +33,4 @@ public record Chunk(ByteBuffer data, AtomicBoolean dirty) {
 		return dirty.get();
 	}
 
-	@Override
-	public String toString() {
-		return format("ChunkData(dirty: %s, length: %d)", dirty, data.limit());
-	}
-
 }

--- a/src/main/java/org/cryptomator/cryptofs/fh/ChunkCache.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/ChunkCache.java
@@ -20,7 +20,7 @@ public class ChunkCache {
 	private final ChunkSaver chunkSaver;
 	private final CryptoFileSystemStats stats;
 	private final BufferPool bufferPool;
-	private final Cache<Long, ChunkData> chunks;
+	private final Cache<Long, Chunk> chunks;
 
 	@Inject
 	public ChunkCache(ChunkLoader chunkLoader, ChunkSaver chunkSaver, CryptoFileSystemStats stats, BufferPool bufferPool) {
@@ -34,7 +34,7 @@ public class ChunkCache {
 				.build();
 	}
 
-	private ChunkData loadChunk(long chunkIndex) throws IOException {
+	private Chunk loadChunk(long chunkIndex) throws IOException {
 		stats.addChunkCacheMiss();
 		try {
 			return chunkLoader.load(chunkIndex);
@@ -44,7 +44,7 @@ public class ChunkCache {
 		}
 	}
 
-	private void removeChunk(RemovalNotification<Long, ChunkData> removal) {
+	private void removeChunk(RemovalNotification<Long, Chunk> removal) {
 		try {
 			chunkSaver.save(removal.getKey(), removal.getValue());
 			bufferPool.recycle(removal.getValue().data());
@@ -53,7 +53,7 @@ public class ChunkCache {
 		}
 	}
 
-	public ChunkData get(long chunkIndex) throws IOException {
+	public Chunk get(long chunkIndex) throws IOException {
 		try {
 			stats.addChunkCacheAccess();
 			return chunks.get(chunkIndex, () -> loadChunk(chunkIndex));
@@ -63,7 +63,7 @@ public class ChunkCache {
 		}
 	}
 
-	public void set(long chunkIndex, ChunkData data) {
+	public void set(long chunkIndex, Chunk data) {
 		chunks.put(chunkIndex, data);
 	}
 

--- a/src/main/java/org/cryptomator/cryptofs/fh/ChunkLoader.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/ChunkLoader.java
@@ -26,7 +26,7 @@ class ChunkLoader {
 		this.bufferPool = bufferPool;
 	}
 
-	public ChunkData load(Long chunkIndex) throws IOException, AuthenticationFailedException {
+	public Chunk load(Long chunkIndex) throws IOException, AuthenticationFailedException {
 		stats.addChunkCacheMiss();
 		int chunkSize = cryptor.fileContentCryptor().ciphertextChunkSize();
 		long ciphertextPos = chunkIndex * chunkSize + cryptor.fileHeaderCryptor().headerSize();
@@ -42,7 +42,7 @@ class ChunkLoader {
 				cleartextBuf.flip();
 				stats.addBytesDecrypted(cleartextBuf.remaining());
 			}
-			return new ChunkData(cleartextBuf, false);
+			return new Chunk(cleartextBuf, false);
 		} finally {
 			bufferPool.recycle(ciphertextBuf);
 		}

--- a/src/main/java/org/cryptomator/cryptofs/fh/ChunkLoader.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/ChunkLoader.java
@@ -15,38 +15,36 @@ class ChunkLoader {
 	private final ChunkIO ciphertext;
 	private final FileHeaderHolder headerHolder;
 	private final CryptoFileSystemStats stats;
+	private final BufferPool bufferPool;
 
 	@Inject
-	public ChunkLoader(Cryptor cryptor, ChunkIO ciphertext, FileHeaderHolder headerHolder, CryptoFileSystemStats stats) {
+	public ChunkLoader(Cryptor cryptor, ChunkIO ciphertext, FileHeaderHolder headerHolder, CryptoFileSystemStats stats, BufferPool bufferPool) {
 		this.cryptor = cryptor;
 		this.ciphertext = ciphertext;
 		this.headerHolder = headerHolder;
 		this.stats = stats;
+		this.bufferPool = bufferPool;
 	}
 
 	public ChunkData load(Long chunkIndex) throws IOException, AuthenticationFailedException {
 		stats.addChunkCacheMiss();
-		int payloadSize = cryptor.fileContentCryptor().cleartextChunkSize();
 		int chunkSize = cryptor.fileContentCryptor().ciphertextChunkSize();
 		long ciphertextPos = chunkIndex * chunkSize + cryptor.fileHeaderCryptor().headerSize();
-		ByteBuffer ciphertextBuf = ByteBuffer.allocate(chunkSize);
-		int read = ciphertext.read(ciphertextBuf, ciphertextPos);
-		if (read == -1) {
-			// append
-			return ChunkData.emptyWithSize(payloadSize);
-		} else {
-			ciphertextBuf.flip();
-			ByteBuffer cleartextBuf = cryptor.fileContentCryptor().decryptChunk(ciphertextBuf, chunkIndex, headerHolder.get(), true);
-			stats.addBytesDecrypted(cleartextBuf.remaining());
-			ByteBuffer cleartextBufWhichCanHoldFullChunk;
-			if (cleartextBuf.capacity() < payloadSize) {
-				cleartextBufWhichCanHoldFullChunk = ByteBuffer.allocate(payloadSize);
-				cleartextBufWhichCanHoldFullChunk.put(cleartextBuf);
-				cleartextBufWhichCanHoldFullChunk.flip();
+		ByteBuffer ciphertextBuf = bufferPool.getCiphertextBuffer();
+		ByteBuffer cleartextBuf = bufferPool.getCleartextBuffer();
+		try {
+			int read = ciphertext.read(ciphertextBuf, ciphertextPos);
+			if (read == -1) {
+				cleartextBuf.limit(0);
 			} else {
-				cleartextBufWhichCanHoldFullChunk = cleartextBuf;
+				ciphertextBuf.flip();
+				cryptor.fileContentCryptor().decryptChunk(ciphertextBuf, cleartextBuf, chunkIndex, headerHolder.get(), true);
+				cleartextBuf.flip();
+				stats.addBytesDecrypted(cleartextBuf.remaining());
 			}
-			return ChunkData.wrap(cleartextBufWhichCanHoldFullChunk);
+			return new ChunkData(cleartextBuf, false);
+		} finally {
+			bufferPool.recycle(ciphertextBuf);
 		}
 	}
 

--- a/src/main/java/org/cryptomator/cryptofs/fh/ChunkSaver.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/ChunkSaver.java
@@ -27,7 +27,7 @@ class ChunkSaver {
 		this.bufferPool = bufferPool;
 	}
 
-	public void save(long chunkIndex, ChunkData chunkData) throws IOException {
+	public void save(long chunkIndex, Chunk chunkData) throws IOException {
 		if (chunkData.isDirty()) {
 			long ciphertextPos = chunkIndex * cryptor.fileContentCryptor().ciphertextChunkSize() + cryptor.fileHeaderCryptor().headerSize();
 			ByteBuffer cleartextBuf = chunkData.data().duplicate();

--- a/src/main/java/org/cryptomator/cryptofs/fh/ChunkSaver.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/ChunkSaver.java
@@ -15,26 +15,32 @@ class ChunkSaver {
 	private final FileHeaderHolder headerHolder;
 	private final ExceptionsDuringWrite exceptionsDuringWrite;
 	private final CryptoFileSystemStats stats;
+	private final BufferPool bufferPool;
 
 	@Inject
-	public ChunkSaver(Cryptor cryptor, ChunkIO ciphertext, FileHeaderHolder headerHolder, ExceptionsDuringWrite exceptionsDuringWrite, CryptoFileSystemStats stats) {
+	public ChunkSaver(Cryptor cryptor, ChunkIO ciphertext, FileHeaderHolder headerHolder, ExceptionsDuringWrite exceptionsDuringWrite, CryptoFileSystemStats stats, BufferPool bufferPool) {
 		this.cryptor = cryptor;
 		this.ciphertext = ciphertext;
 		this.headerHolder = headerHolder;
 		this.exceptionsDuringWrite = exceptionsDuringWrite;
 		this.stats = stats;
+		this.bufferPool = bufferPool;
 	}
 
 	public void save(long chunkIndex, ChunkData chunkData) throws IOException {
 		if (chunkData.isDirty()) {
 			long ciphertextPos = chunkIndex * cryptor.fileContentCryptor().ciphertextChunkSize() + cryptor.fileHeaderCryptor().headerSize();
-			ByteBuffer cleartextBuf = chunkData.asReadOnlyBuffer();
+			ByteBuffer cleartextBuf = chunkData.data().duplicate();
 			stats.addBytesEncrypted(cleartextBuf.remaining());
-			ByteBuffer ciphertextBuf = cryptor.fileContentCryptor().encryptChunk(cleartextBuf, chunkIndex, headerHolder.get());
+			ByteBuffer ciphertextBuf = bufferPool.getCiphertextBuffer();
 			try {
+				cryptor.fileContentCryptor().encryptChunk(cleartextBuf, ciphertextBuf, chunkIndex, headerHolder.get());
+				ciphertextBuf.flip();
 				ciphertext.write(ciphertextBuf, ciphertextPos);
 			} catch (IOException e) {
 				exceptionsDuringWrite.add(e);
+			} finally {
+				bufferPool.recycle(ciphertextBuf);
 			} // unchecked exceptions will be propagated to the thread causing removal
 		}
 	}

--- a/src/test/java/org/cryptomator/cryptofs/ch/CleartextFileChannelTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/ch/CleartextFileChannelTest.java
@@ -3,7 +3,7 @@ package org.cryptomator.cryptofs.ch;
 import org.cryptomator.cryptofs.CryptoFileSystemStats;
 import org.cryptomator.cryptofs.EffectiveOpenOptions;
 import org.cryptomator.cryptofs.fh.ChunkCache;
-import org.cryptomator.cryptofs.fh.ChunkData;
+import org.cryptomator.cryptofs.fh.Chunk;
 import org.cryptomator.cryptofs.fh.ExceptionsDuringWrite;
 import org.cryptomator.cryptolib.api.Cryptor;
 import org.cryptomator.cryptolib.api.FileContentCryptor;
@@ -74,7 +74,7 @@ public class CleartextFileChannelTest {
 	public void setUp() throws IOException {
 		when(cryptor.fileHeaderCryptor()).thenReturn(fileHeaderCryptor);
 		when(cryptor.fileContentCryptor()).thenReturn(fileContentCryptor);
-		when(chunkCache.get(Mockito.anyLong())).then(invocation -> new ChunkData(ByteBuffer.allocate(100), false));
+		when(chunkCache.get(Mockito.anyLong())).then(invocation -> new Chunk(ByteBuffer.allocate(100), false));
 		when(fileHeaderCryptor.headerSize()).thenReturn(50);
 		when(fileContentCryptor.cleartextChunkSize()).thenReturn(100);
 		when(fileContentCryptor.ciphertextChunkSize()).thenReturn(110);

--- a/src/test/java/org/cryptomator/cryptofs/ch/CleartextFileChannelTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/ch/CleartextFileChannelTest.java
@@ -74,7 +74,7 @@ public class CleartextFileChannelTest {
 	public void setUp() throws IOException {
 		when(cryptor.fileHeaderCryptor()).thenReturn(fileHeaderCryptor);
 		when(cryptor.fileContentCryptor()).thenReturn(fileContentCryptor);
-		when(chunkCache.get(Mockito.anyLong())).then(invocation -> ChunkData.wrap(ByteBuffer.allocate(100)));
+		when(chunkCache.get(Mockito.anyLong())).then(invocation -> new ChunkData(ByteBuffer.allocate(100), false));
 		when(fileHeaderCryptor.headerSize()).thenReturn(50);
 		when(fileContentCryptor.cleartextChunkSize()).thenReturn(100);
 		when(fileContentCryptor.ciphertextChunkSize()).thenReturn(110);
@@ -134,7 +134,6 @@ public class CleartextFileChannelTest {
 			when(options.writable()).thenReturn(true);
 
 			inTest.truncate(newSize);
-
 
 			MatcherAssert.assertThat(inTest.position(), is(currentPosition));
 		}

--- a/src/test/java/org/cryptomator/cryptofs/fh/BufferPoolTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/fh/BufferPoolTest.java
@@ -1,0 +1,107 @@
+package org.cryptomator.cryptofs.fh;
+
+import org.cryptomator.cryptolib.api.Cryptor;
+import org.cryptomator.cryptolib.api.FileContentCryptor;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+
+import java.nio.ByteBuffer;
+
+public class BufferPoolTest {
+
+	private static final int CLEARTEXT_CHUNK_SIZE = 100;
+	private static final int CIPHERTEXT_CHUNK_SIZE = 150;
+
+	private final Cryptor cryptor = Mockito.mock(Cryptor.class);
+	private final FileContentCryptor fileContentCryptor = Mockito.mock(FileContentCryptor.class);
+	private BufferPool bufferPool;
+
+	@BeforeEach
+	public void setup() {
+		Mockito.doReturn(fileContentCryptor).when(cryptor).fileContentCryptor();
+		Mockito.doReturn(CLEARTEXT_CHUNK_SIZE).when(fileContentCryptor).cleartextChunkSize();
+		Mockito.doReturn(CIPHERTEXT_CHUNK_SIZE).when(fileContentCryptor).ciphertextChunkSize();
+		bufferPool = new BufferPool(cryptor);
+	}
+
+	@Test
+	@DisplayName("getCiphertextBuffer() with no cached item")
+	public void testGetUncachedCiphertextBuffer() {
+		try (var byteBufferClass = Mockito.mockStatic(ByteBuffer.class)) {
+			byteBufferClass.when(() -> ByteBuffer.allocate(Mockito.anyInt())).thenCallRealMethod();
+			var buf = bufferPool.getCiphertextBuffer();
+
+			Assertions.assertEquals(CIPHERTEXT_CHUNK_SIZE, buf.capacity());
+			byteBufferClass.verify(() -> ByteBuffer.allocate(CIPHERTEXT_CHUNK_SIZE));
+		}
+	}
+
+	@Test
+	@DisplayName("getCiphertextBuffer() after recycling ciphertext")
+	public void testGetCachedCiphertextBuffer() {
+		var buf0 = ByteBuffer.allocate(CIPHERTEXT_CHUNK_SIZE);
+		bufferPool.recycle(buf0);
+		buf0 = null;
+		System.gc(); // seems to be reliable on Temurin 17 with @RepeatedTest(1000)
+
+		var buf1 = ByteBuffer.allocate(CIPHERTEXT_CHUNK_SIZE);
+		bufferPool.recycle(buf1);
+
+		try (var byteBufferClass = Mockito.mockStatic(ByteBuffer.class)) {
+			var buf2 = bufferPool.getCiphertextBuffer();
+
+			Assertions.assertSame(buf1, buf2);
+			Assertions.assertEquals(0, buf2.position(), "expected recycled buffer to be cleared");
+			Assertions.assertEquals(buf2.capacity(), buf2.limit(), "expected recycled buffer to be cleared");
+			byteBufferClass.verifyNoInteractions();
+		}
+	}
+
+	@Test
+	@DisplayName("getCleartextBuffer() with no cached item")
+	public void testGetUncachedCleartextBuffer() {
+		try (var byteBufferClass = Mockito.mockStatic(ByteBuffer.class)) {
+			byteBufferClass.when(() -> ByteBuffer.allocate(Mockito.anyInt())).thenCallRealMethod();
+			var buf = bufferPool.getCleartextBuffer();
+
+			Assertions.assertEquals(CLEARTEXT_CHUNK_SIZE, buf.capacity());
+			byteBufferClass.verify(() -> ByteBuffer.allocate(CLEARTEXT_CHUNK_SIZE));
+		}
+	}
+
+	@Test
+	@DisplayName("getCleartextBuffer() after recycling cleartext")
+	public void testGetCachedCleartextBuffer() {
+		var buf0 = ByteBuffer.allocate(CIPHERTEXT_CHUNK_SIZE);
+		bufferPool.recycle(buf0);
+		buf0 = null;
+		System.gc(); // seems to be reliable on Temurin 17 with @RepeatedTest(1000)
+
+		var buf1 = ByteBuffer.allocate(CLEARTEXT_CHUNK_SIZE);
+		bufferPool.recycle(buf1);
+
+		try (var byteBufferClass = Mockito.mockStatic(ByteBuffer.class)) {
+			var buf2 = bufferPool.getCleartextBuffer();
+
+			Assertions.assertSame(buf1, buf2);
+			Assertions.assertEquals(0, buf2.position(), "expected recycled buffer to be cleared");
+			Assertions.assertEquals(buf2.capacity(), buf2.limit(), "expected recycled buffer to be cleared");
+			byteBufferClass.verifyNoInteractions();
+		}
+	}
+
+	@DisplayName("recycle() accepts any size")
+	@ParameterizedTest
+	@ValueSource(ints = {CIPHERTEXT_CHUNK_SIZE, CLEARTEXT_CHUNK_SIZE, 42})
+	public void testRecycle(int capacity) {
+		var buf = ByteBuffer.allocate(capacity);
+
+		Assertions.assertDoesNotThrow(() -> bufferPool.recycle(buf));
+	}
+
+}

--- a/src/test/java/org/cryptomator/cryptofs/fh/ChunkCacheTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/fh/ChunkCacheTest.java
@@ -25,21 +25,21 @@ public class ChunkCacheTest {
 	@Test
 	public void testGetInvokesLoaderIfEntryNotInCache() throws IOException, AuthenticationFailedException {
 		long index = 42L;
-		ChunkData data = mock(ChunkData.class);
-		when(chunkLoader.load(index)).thenReturn(data);
+		Chunk chunk = mock(Chunk.class);
+		when(chunkLoader.load(index)).thenReturn(chunk);
 
-		Assertions.assertSame(data, inTest.get(index));
+		Assertions.assertSame(chunk, inTest.get(index));
 		verify(stats).addChunkCacheAccess();
 	}
 
 	@Test
 	public void testGetDoesNotInvokeLoaderIfEntryInCacheFromPreviousGet() throws IOException, AuthenticationFailedException {
 		long index = 42L;
-		ChunkData data = mock(ChunkData.class);
-		when(chunkLoader.load(index)).thenReturn(data);
+		Chunk chunk = mock(Chunk.class);
+		when(chunkLoader.load(index)).thenReturn(chunk);
 		inTest.get(index);
 
-		Assertions.assertSame(data, inTest.get(index));
+		Assertions.assertSame(chunk, inTest.get(index));
 		verify(stats, Mockito.times(2)).addChunkCacheAccess();
 		verify(chunkLoader).load(index);
 	}
@@ -47,10 +47,10 @@ public class ChunkCacheTest {
 	@Test
 	public void testGetDoesNotInvokeLoaderIfEntryInCacheFromPreviousSet() throws IOException {
 		long index = 42L;
-		ChunkData data = mock(ChunkData.class);
-		inTest.set(index, data);
+		Chunk chunk = mock(Chunk.class);
+		inTest.set(index, chunk);
 
-		Assertions.assertSame(data, inTest.get(index));
+		Assertions.assertSame(chunk, inTest.get(index));
 		verify(stats).addChunkCacheAccess();
 	}
 
@@ -58,18 +58,18 @@ public class ChunkCacheTest {
 	public void testGetInvokesSaverIfMaxEntriesInCacheAreReachedAndAnEntryNotInCacheIsRequested() throws IOException, AuthenticationFailedException {
 		long firstIndex = 42L;
 		long indexNotInCache = 40L;
-		ChunkData firstData = mock(ChunkData.class);
-		inTest.set(firstIndex, firstData);
+		Chunk chunk = mock(Chunk.class);
+		inTest.set(firstIndex, chunk);
 		for (int i = 1; i < ChunkCache.MAX_CACHED_CLEARTEXT_CHUNKS; i++) {
-			inTest.set(firstIndex + i, mock(ChunkData.class));
+			inTest.set(firstIndex + i, mock(Chunk.class));
 		}
-		when(chunkLoader.load(indexNotInCache)).thenReturn(mock(ChunkData.class));
+		when(chunkLoader.load(indexNotInCache)).thenReturn(mock(Chunk.class));
 
 		inTest.get(indexNotInCache);
 
 		verify(stats).addChunkCacheAccess();
-		verify(chunkSaver).save(firstIndex, firstData);
-		verify(bufferPool).recycle(firstData.data());
+		verify(chunkSaver).save(firstIndex, chunk);
+		verify(bufferPool).recycle(chunk.data());
 		verifyNoMoreInteractions(chunkSaver);
 	}
 
@@ -77,16 +77,16 @@ public class ChunkCacheTest {
 	public void testGetInvokesSaverIfMaxEntriesInCacheAreReachedAndAnEntryNotInCacheIsSet() throws IOException {
 		long firstIndex = 42L;
 		long indexNotInCache = 40L;
-		ChunkData firstData = mock(ChunkData.class);
-		inTest.set(firstIndex, firstData);
+		Chunk chunk = mock(Chunk.class);
+		inTest.set(firstIndex, chunk);
 		for (int i = 1; i < ChunkCache.MAX_CACHED_CLEARTEXT_CHUNKS; i++) {
-			inTest.set(firstIndex + i, mock(ChunkData.class));
+			inTest.set(firstIndex + i, mock(Chunk.class));
 		}
 
-		inTest.set(indexNotInCache, mock(ChunkData.class));
+		inTest.set(indexNotInCache, mock(Chunk.class));
 
-		verify(chunkSaver).save(firstIndex, firstData);
-		verify(bufferPool).recycle(firstData.data());
+		verify(chunkSaver).save(firstIndex, chunk);
+		verify(bufferPool).recycle(chunk.data());
 		verifyNoMoreInteractions(chunkSaver);
 	}
 
@@ -94,16 +94,16 @@ public class ChunkCacheTest {
 	public void testGetInvokesSaverIfMaxEntriesInCacheAreReachedAndAnEntryInCacheIsSet() throws IOException {
 		// TODO markuskreusch: this behaviour isn't actually needed, maybe we can somehow prevent saving in such situations?
 		long firstIndex = 42L;
-		ChunkData firstData = mock(ChunkData.class);
-		inTest.set(firstIndex, firstData);
+		Chunk chunk = mock(Chunk.class);
+		inTest.set(firstIndex, chunk);
 		for (int i = 1; i < ChunkCache.MAX_CACHED_CLEARTEXT_CHUNKS; i++) {
-			inTest.set(firstIndex + i, mock(ChunkData.class));
+			inTest.set(firstIndex + i, mock(Chunk.class));
 		}
 
-		inTest.set(firstIndex, mock(ChunkData.class));
+		inTest.set(firstIndex, mock(Chunk.class));
 
-		verify(chunkSaver).save(firstIndex, firstData);
-		verify(bufferPool).recycle(firstData.data());
+		verify(chunkSaver).save(firstIndex, chunk);
+		verify(bufferPool).recycle(chunk.data());
 		verifyNoMoreInteractions(chunkSaver);
 	}
 
@@ -135,8 +135,8 @@ public class ChunkCacheTest {
 	public void testInvalidateAllInvokesSaverForAllEntriesInCache() throws IOException, AuthenticationFailedException {
 		long index = 42L;
 		long index2 = 43L;
-		ChunkData chunk1 = mock(ChunkData.class);
-		ChunkData chunk2 = mock(ChunkData.class);
+		Chunk chunk1 = mock(Chunk.class);
+		Chunk chunk2 = mock(Chunk.class);
 		when(chunk1.data()).thenReturn(ByteBuffer.allocate(42));
 		when(chunk2.data()).thenReturn(ByteBuffer.allocate(23));
 		when(chunkLoader.load(index)).thenReturn(chunk1);

--- a/src/test/java/org/cryptomator/cryptofs/fh/ChunkDataTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/fh/ChunkDataTest.java
@@ -1,10 +1,7 @@
 package org.cryptomator.cryptofs.fh;
 
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -13,124 +10,42 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.LongAdder;
-import java.util.stream.Stream;
 
-import static org.cryptomator.cryptofs.matchers.ByteBufferMatcher.contains;
 import static org.cryptomator.cryptofs.util.ByteBuffers.repeat;
-import static org.hamcrest.Matchers.is;
 
 public class ChunkDataTest {
-
-	private static final int SIZE = 200;
-
-	public static Stream<WayToCreateEmptyChunkData> waysToCreateEmptyChunkData() {
-		return Stream.of(
-				new CreateEmptyChunkData(), //
-				new WrapEmptyBuffer() //
-		);
-	}
-
-	public static Stream<WayToCreateChunkDataWithContent> waysToCreateChunkDataWithContent() { //
-		return Stream.of(
-				new WrapBuffer(), //
-				new CreateEmptyChunkDataAndCopyFromBuffer(), //
-				new WrapEmptyBufferAndCopyFromBuffer(), //
-				new WrapPartOfBufferAndCopyRemainingFromBuffer() //
-		);
-	}
 
 	@Test
 	public void testChunkDataWrappingBufferIsNotDirty() {
 		ByteBuffer buffer = repeat(3).times(200).asByteBuffer();
 
-		ChunkData inTest = ChunkData.wrap(buffer);
+		ChunkData inTest = new ChunkData(buffer, false);
 
 		Assertions.assertFalse(inTest.isDirty());
 	}
 
 	@Test
 	public void testEmptyChunkDataIsNotDirty() {
-		ChunkData inTest = ChunkData.emptyWithSize(200);
+		ByteBuffer buffer = ByteBuffer.allocate(0);
+
+		ChunkData inTest = new ChunkData(buffer, false);
 
 		Assertions.assertFalse(inTest.isDirty());
 	}
 
 	@Test
-	public void testWrittenChunkDataIsDirty() {
-		ChunkData inTest = ChunkData.emptyWithSize(200);
-		inTest.copyData().from(repeat(3).times(200).asByteBuffer());
-
-		Assertions.assertTrue(inTest.isDirty());
-	}
-
-	@Test
 	public void testToString() {
-		ChunkData inTest = ChunkData.emptyWithSize(150);
-		inTest.copyDataStartingAt(50).from(repeat(3).times(50).asByteBuffer());
+		ByteBuffer buffer = ByteBuffer.allocate(100);
 
-		MatcherAssert.assertThat(inTest.toString(), is("ChunkData(dirty: true, length: 100, capacity: 150)"));
-	}
+		ChunkData inTest = new ChunkData(buffer, true);
 
-	@ParameterizedTest
-	@MethodSource("waysToCreateEmptyChunkData")
-	public void testAsReadOnlyBufferReturnsEmptyBufferIfEmpty(WayToCreateEmptyChunkData wayToCreateEmptyChunkData) {
-		ChunkData inTest = wayToCreateEmptyChunkData.create();
-
-		MatcherAssert.assertThat(inTest.asReadOnlyBuffer(), contains(new byte[0]));
-	}
-
-	@ParameterizedTest
-	@MethodSource("waysToCreateChunkDataWithContent")
-	public void testAsReadOnlyBufferReturnsContent(WayToCreateChunkDataWithContent wayToCreateChunkDataWithContent) {
-		ChunkData inTest = wayToCreateChunkDataWithContent.create(repeat(3).times(SIZE).asByteBuffer());
-
-		MatcherAssert.assertThat(inTest.asReadOnlyBuffer(), contains(repeat(3).times(SIZE).asByteBuffer()));
-	}
-
-	@ParameterizedTest
-	@MethodSource("waysToCreateChunkDataWithContent")
-	public void testCopyToCopiesContent(WayToCreateChunkDataWithContent wayToCreateChunkDataWithContent) {
-		ChunkData inTest = wayToCreateChunkDataWithContent.create(repeat(3).times(SIZE).asByteBuffer());
-		ByteBuffer target = ByteBuffer.allocate(200);
-
-		inTest.copyData().to(target);
-		target.flip();
-
-		MatcherAssert.assertThat(target, contains(repeat(3).times(SIZE).asByteBuffer()));
-	}
-
-	@ParameterizedTest
-	@MethodSource("waysToCreateEmptyChunkData")
-	public void testCopyToCopiesNothingIfEmpty(WayToCreateEmptyChunkData wayToCreateEmptyChunkData) {
-		ChunkData inTest = wayToCreateEmptyChunkData.create();
-		ByteBuffer target = ByteBuffer.allocate(SIZE);
-
-		inTest.copyData().to(target);
-
-		MatcherAssert.assertThat(target, contains(repeat(0).times(SIZE).asByteBuffer()));
-	}
-
-	@ParameterizedTest
-	@MethodSource("waysToCreateChunkDataWithContent")
-	public void testCopyToWithOffsetCopiesContentFromOffset(WayToCreateChunkDataWithContent wayToCreateChunkDataWithContent) {
-		int offset = 70;
-		ChunkData inTest = wayToCreateChunkDataWithContent.create(repeat(3).times(SIZE).asByteBuffer());
-		ByteBuffer target = ByteBuffer.allocate(SIZE);
-
-		inTest.copyDataStartingAt(offset).to(target);
-
-		target.limit(SIZE - offset);
-		target.position(0);
-		MatcherAssert.assertThat(target, contains(repeat(3).times(SIZE - offset).asByteBuffer()));
-		target.limit(SIZE);
-		target.position(SIZE - offset);
-		MatcherAssert.assertThat(target, contains(repeat(0).times(offset).asByteBuffer()));
+		Assertions.assertEquals("ChunkData(dirty: true, length: 100)", inTest.toString());
 	}
 
 	@Test // https://github.com/cryptomator/cryptofs/issues/85
-	public void testRaceConditionsDuringRead() throws InterruptedException {
+	public void testRaceConditionsDuringRead() {
 		ByteBuffer src = StandardCharsets.US_ASCII.encode("abcdefg");
-		ChunkData inTest = ChunkData.wrap(src);
+		ChunkData inTest = new ChunkData(src, false);
 		int attempts = 4000;
 		int threads = 6;
 
@@ -144,8 +59,7 @@ public class ChunkDataTest {
 			executor.execute(() -> {
 				try {
 					ByteBuffer dst = ByteBuffer.allocate(1);
-					inTest.copyDataStartingAt(offset).to(dst);
-					dst.flip();
+					dst.put(0, inTest.data(), offset, 1);
 					char actual = StandardCharsets.US_ASCII.decode(dst).charAt(0);
 					if (expected == actual) {
 						successfulTests.increment();
@@ -158,124 +72,6 @@ public class ChunkDataTest {
 
 		Assertions.assertTimeoutPreemptively(Duration.ofSeconds(5), () -> cdl.await());
 		Assertions.assertEquals(attempts, successfulTests.sum());
-	}
-
-	interface WayToCreateEmptyChunkData {
-
-		ChunkData create();
-
-	}
-
-	interface WayToCreateChunkDataWithContent {
-
-		ChunkData create(ByteBuffer content);
-
-	}
-
-	private static class CreateEmptyChunkData implements WayToCreateEmptyChunkData {
-
-		@Override
-		public ChunkData create() {
-			return ChunkData.emptyWithSize(SIZE);
-		}
-
-		@Override
-		public String toString() {
-			return "CreateEmptyChunkData";
-		}
-
-	}
-
-	private static class WrapEmptyBuffer implements WayToCreateEmptyChunkData {
-
-		@Override
-		public ChunkData create() {
-			ByteBuffer buffer = ByteBuffer.allocate(SIZE);
-			buffer.limit(0);
-			return ChunkData.wrap(buffer);
-		}
-
-		@Override
-		public String toString() {
-			return "WrapEmptyBuffer";
-		}
-
-	}
-
-	private static class WrapBuffer implements WayToCreateChunkDataWithContent {
-
-		@Override
-		public ChunkData create(ByteBuffer content) {
-			return ChunkData.wrap(content);
-		}
-
-		@Override
-		public String toString() {
-			return "WrapBuffer";
-		}
-
-	}
-
-	private static class CreateEmptyChunkDataAndCopyFromBuffer implements WayToCreateChunkDataWithContent {
-
-		@Override
-		public ChunkData create(ByteBuffer content) {
-			ChunkData result = ChunkData.emptyWithSize(content.remaining());
-			result.copyData().from(content);
-			return result;
-		}
-
-		@Override
-		public String toString() {
-			return "CreateEmptyChunkDataAndCopyFromBuffer";
-		}
-
-	}
-
-	private static class WrapEmptyBufferAndCopyFromBuffer implements WayToCreateChunkDataWithContent {
-
-		@Override
-		public ChunkData create(ByteBuffer content) {
-			ByteBuffer buffer = ByteBuffer.allocate(content.remaining());
-			buffer.limit(0);
-			ChunkData result = ChunkData.wrap(buffer);
-			result.copyData().from(content.asReadOnlyBuffer());
-			return result;
-		}
-
-		@Override
-		public String toString() {
-			return "WrapEmptyBufferAndCopyFromBuffer";
-		}
-
-	}
-
-	private static class WrapPartOfBufferAndCopyRemainingFromBuffer implements WayToCreateChunkDataWithContent {
-
-		@Override
-		public ChunkData create(ByteBuffer content) {
-			int position = content.position();
-			int remaining = content.remaining();
-			int halfRemaining = remaining / 2;
-
-			ByteBuffer readOnlyContent = content.asReadOnlyBuffer();
-			readOnlyContent.limit(position + halfRemaining);
-			ByteBuffer wrappedContent = ByteBuffer.allocate(remaining);
-			wrappedContent.put(readOnlyContent);
-			wrappedContent.limit(halfRemaining);
-			ChunkData result = ChunkData.wrap(wrappedContent);
-
-			readOnlyContent.limit(position + remaining);
-			result.copyDataStartingAt(halfRemaining).from(readOnlyContent);
-
-			return result;
-		}
-
-		@Override
-		public String toString() {
-			return "WrapPartOfBufferAndCopyRemainingFromBuffer";
-		}
-
 	}
 
 }

--- a/src/test/java/org/cryptomator/cryptofs/fh/ChunkLoaderTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/fh/ChunkLoaderTest.java
@@ -1,6 +1,7 @@
 package org.cryptomator.cryptofs.fh;
 
 import org.cryptomator.cryptofs.CryptoFileSystemStats;
+import org.cryptomator.cryptofs.matchers.ByteBufferMatcher;
 import org.cryptomator.cryptolib.api.AuthenticationFailedException;
 import org.cryptomator.cryptolib.api.Cryptor;
 import org.cryptomator.cryptolib.api.FileContentCryptor;
@@ -67,6 +68,7 @@ public class ChunkLoaderTest {
 		Chunk chunk = inTest.load(chunkIndex);
 
 		verify(stats).addChunkCacheMiss();
+		verify(bufferPool).recycle(argThat(ByteBufferMatcher.hasCapacity(CIPHERTEXT_CHUNK_SIZE)));
 		Assertions.assertEquals(0, chunk.data().remaining());
 		Assertions.assertEquals(CLEARTEXT_CHUNK_SIZE, chunk.data().capacity());
 	}
@@ -91,6 +93,7 @@ public class ChunkLoaderTest {
 
 		verify(stats).addChunkCacheMiss();
 		verify(stats).addBytesDecrypted(chunk.data().remaining());
+		verify(bufferPool).recycle(argThat(ByteBufferMatcher.hasCapacity(CIPHERTEXT_CHUNK_SIZE)));
 		assertThat(chunk.data(), contains(decryptedData.get()));
 		Assertions.assertEquals(CLEARTEXT_CHUNK_SIZE, chunk.data().remaining());
 		Assertions.assertEquals(CLEARTEXT_CHUNK_SIZE, chunk.data().capacity());
@@ -116,6 +119,7 @@ public class ChunkLoaderTest {
 
 		verify(stats).addChunkCacheMiss();
 		verify(stats).addBytesDecrypted(chunk.data().remaining());
+		verify(bufferPool).recycle(argThat(ByteBufferMatcher.hasCapacity(CIPHERTEXT_CHUNK_SIZE)));
 		assertThat(chunk.data(), contains(decryptedData.get()));
 		Assertions.assertEquals(CLEARTEXT_CHUNK_SIZE - 3, chunk.data().remaining());
 		Assertions.assertEquals(CLEARTEXT_CHUNK_SIZE, chunk.data().capacity());

--- a/src/test/java/org/cryptomator/cryptofs/fh/ChunkLoaderTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/fh/ChunkLoaderTest.java
@@ -64,7 +64,7 @@ public class ChunkLoaderTest {
 		long chunkOffset = chunkIndex * CIPHERTEXT_CHUNK_SIZE + HEADER_SIZE;
 		when(chunkIO.read(argThat(hasAtLeastRemaining(CIPHERTEXT_CHUNK_SIZE)), eq(chunkOffset))).thenReturn(-1);
 
-		ChunkData chunk = inTest.load(chunkIndex);
+		Chunk chunk = inTest.load(chunkIndex);
 
 		verify(stats).addChunkCacheMiss();
 		Assertions.assertEquals(0, chunk.data().remaining());
@@ -87,7 +87,7 @@ public class ChunkLoaderTest {
 				Mockito.any(), eq(chunkIndex), eq(header), eq(true) //
 		);
 
-		ChunkData chunk = inTest.load(chunkIndex);
+		Chunk chunk = inTest.load(chunkIndex);
 
 		verify(stats).addChunkCacheMiss();
 		verify(stats).addBytesDecrypted(chunk.data().remaining());
@@ -112,7 +112,7 @@ public class ChunkLoaderTest {
 				any(ByteBuffer.class), eq(chunkIndex), eq(header), eq(true) //
 		);
 
-		ChunkData chunk = inTest.load(chunkIndex);
+		Chunk chunk = inTest.load(chunkIndex);
 
 		verify(stats).addChunkCacheMiss();
 		verify(stats).addBytesDecrypted(chunk.data().remaining());

--- a/src/test/java/org/cryptomator/cryptofs/fh/ChunkLoaderTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/fh/ChunkLoaderTest.java
@@ -6,8 +6,11 @@ import org.cryptomator.cryptolib.api.Cryptor;
 import org.cryptomator.cryptolib.api.FileContentCryptor;
 import org.cryptomator.cryptolib.api.FileHeader;
 import org.cryptomator.cryptolib.api.FileHeaderCryptor;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
@@ -18,7 +21,9 @@ import static org.cryptomator.cryptofs.matchers.ByteBufferMatcher.contains;
 import static org.cryptomator.cryptofs.matchers.ByteBufferMatcher.hasAtLeastRemaining;
 import static org.cryptomator.cryptofs.util.ByteBuffers.repeat;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -37,7 +42,8 @@ public class ChunkLoaderTest {
 	private final CryptoFileSystemStats stats = mock(CryptoFileSystemStats.class);
 	private final FileHeader header = mock(FileHeader.class);
 	private final FileHeaderHolder headerHolder = mock(FileHeaderHolder.class);
-	private final ChunkLoader inTest = new ChunkLoader(cryptor, chunkIO, headerHolder, stats);
+	private final BufferPool bufferPool = mock(BufferPool.class);
+	private final ChunkLoader inTest = new ChunkLoader(cryptor, chunkIO, headerHolder, stats, bufferPool);
 
 	@BeforeEach
 	public void setup() throws IOException {
@@ -47,58 +53,72 @@ public class ChunkLoaderTest {
 		when(fileContentCryptor.ciphertextChunkSize()).thenReturn(CIPHERTEXT_CHUNK_SIZE);
 		when(fileContentCryptor.cleartextChunkSize()).thenReturn(CLEARTEXT_CHUNK_SIZE);
 		when(fileHeaderCryptor.headerSize()).thenReturn(HEADER_SIZE);
+		when(bufferPool.getCiphertextBuffer()).thenAnswer(invocation -> ByteBuffer.allocate(CIPHERTEXT_CHUNK_SIZE));
+		when(bufferPool.getCleartextBuffer()).thenAnswer(invocation -> ByteBuffer.allocate(CLEARTEXT_CHUNK_SIZE));
 	}
 
 	@Test
-	public void testChunkLoaderReturnsEmptyDataOfChunkAfterEndOfFile() throws IOException, AuthenticationFailedException {
+	@DisplayName("load() returns empty chunk when hitting EOF")
+	public void testLoadReturnsEmptyChunkAfterEOF() throws IOException, AuthenticationFailedException {
 		long chunkIndex = 482L;
 		long chunkOffset = chunkIndex * CIPHERTEXT_CHUNK_SIZE + HEADER_SIZE;
 		when(chunkIO.read(argThat(hasAtLeastRemaining(CIPHERTEXT_CHUNK_SIZE)), eq(chunkOffset))).thenReturn(-1);
 
-		ChunkData data = inTest.load(chunkIndex);
+		ChunkData chunk = inTest.load(chunkIndex);
 
 		verify(stats).addChunkCacheMiss();
-		assertThat(data.asReadOnlyBuffer(), contains(ByteBuffer.allocate(0)));
-		data.copyData().from(repeat(9).times(CLEARTEXT_CHUNK_SIZE).asByteBuffer());
-		assertThat(data.asReadOnlyBuffer(), contains(repeat(9).times(CLEARTEXT_CHUNK_SIZE).asByteBuffer())); // asserts that data has at least CLEARTEXT_CHUNK_SIZE capacity
+		Assertions.assertEquals(0, chunk.data().remaining());
+		Assertions.assertEquals(CLEARTEXT_CHUNK_SIZE, chunk.data().capacity());
 	}
 
 	@Test
-	public void testChunkLoaderReturnsDecryptedDataOfChunkInsideFile() throws IOException, AuthenticationFailedException {
+	@DisplayName("load() returns full chunk when in middle of file")
+	public void testLoadReturnsDecryptedDataInsideFile() throws IOException, AuthenticationFailedException {
 		long chunkIndex = 482L;
 		long chunkOffset = chunkIndex * CIPHERTEXT_CHUNK_SIZE + HEADER_SIZE;
 		Supplier<ByteBuffer> decryptedData = () -> repeat(9).times(CLEARTEXT_CHUNK_SIZE).asByteBuffer();
 		when(chunkIO.read(argThat(hasAtLeastRemaining(CIPHERTEXT_CHUNK_SIZE)), eq(chunkOffset))).then(fillBufferWith((byte) 3, CIPHERTEXT_CHUNK_SIZE));
-		when(fileContentCryptor.decryptChunk( //
+		doAnswer(invocation -> {
+			ByteBuffer cleartextBuf = invocation.getArgument(1);
+			cleartextBuf.put(decryptedData.get());
+			return null;
+		}).when(fileContentCryptor).decryptChunk(
 				argThat(contains(repeat(3).times(CIPHERTEXT_CHUNK_SIZE).asByteBuffer())), //
-				eq(chunkIndex), eq(header), eq(true)) //
-		).thenReturn(decryptedData.get());
+				Mockito.any(), eq(chunkIndex), eq(header), eq(true) //
+		);
 
-		ChunkData data = inTest.load(chunkIndex);
+		ChunkData chunk = inTest.load(chunkIndex);
 
 		verify(stats).addChunkCacheMiss();
-		verify(stats).addBytesDecrypted(data.asReadOnlyBuffer().remaining());
-		assertThat(data.asReadOnlyBuffer(), contains(decryptedData.get()));
+		verify(stats).addBytesDecrypted(chunk.data().remaining());
+		assertThat(chunk.data(), contains(decryptedData.get()));
+		Assertions.assertEquals(CLEARTEXT_CHUNK_SIZE, chunk.data().remaining());
+		Assertions.assertEquals(CLEARTEXT_CHUNK_SIZE, chunk.data().capacity());
 	}
 
 	@Test
-	public void testChunkLoaderReturnsDecrytedDataOfChunkContainingEndOfFile() throws IOException, AuthenticationFailedException {
+	@DisplayName("load() returns partial chunk near EOF")
+	public void testLoadReturnsDecrytedDataNearEOF() throws IOException, AuthenticationFailedException {
 		long chunkIndex = 482L;
 		long chunkOffset = chunkIndex * CIPHERTEXT_CHUNK_SIZE + HEADER_SIZE;
 		Supplier<ByteBuffer> decryptedData = () -> repeat(9).times(CLEARTEXT_CHUNK_SIZE - 3).asByteBuffer();
 		when(chunkIO.read(argThat(hasAtLeastRemaining(CIPHERTEXT_CHUNK_SIZE)), eq(chunkOffset))).then(fillBufferWith((byte) 3, CIPHERTEXT_CHUNK_SIZE - 10));
-		when(fileContentCryptor.decryptChunk( //
+		doAnswer(invocation -> {
+			ByteBuffer cleartextBuf = invocation.getArgument(1);
+			cleartextBuf.put(decryptedData.get());
+			return null;
+		}).when(fileContentCryptor).decryptChunk(
 				argThat(contains(repeat(3).times(CIPHERTEXT_CHUNK_SIZE - 10).asByteBuffer())), //
-				eq(chunkIndex), eq(header), eq(true)) //
-		).thenReturn(decryptedData.get());
+				any(ByteBuffer.class), eq(chunkIndex), eq(header), eq(true) //
+		);
 
-		ChunkData data = inTest.load(chunkIndex);
+		ChunkData chunk = inTest.load(chunkIndex);
 
 		verify(stats).addChunkCacheMiss();
-		verify(stats).addBytesDecrypted(data.asReadOnlyBuffer().remaining());
-		assertThat(data.asReadOnlyBuffer(), contains(decryptedData.get()));
-		data.copyData().from(repeat(9).times(CLEARTEXT_CHUNK_SIZE).asByteBuffer());
-		assertThat(data.asReadOnlyBuffer(), contains(repeat(9).times(CLEARTEXT_CHUNK_SIZE).asByteBuffer())); // asserts that data has at least CLEARTEXT_CHUNK_SIZE capacity
+		verify(stats).addBytesDecrypted(chunk.data().remaining());
+		assertThat(chunk.data(), contains(decryptedData.get()));
+		Assertions.assertEquals(CLEARTEXT_CHUNK_SIZE - 3, chunk.data().remaining());
+		Assertions.assertEquals(CLEARTEXT_CHUNK_SIZE, chunk.data().capacity());
 	}
 
 	private Answer<Integer> fillBufferWith(byte value, int amount) {

--- a/src/test/java/org/cryptomator/cryptofs/fh/ChunkSaverTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/fh/ChunkSaverTest.java
@@ -69,6 +69,7 @@ public class ChunkSaverTest {
 
 		verify(chunkIO).write(argThat(contains(ciphertext.get())), eq(expectedPosition));
 		verify(stats).addBytesEncrypted(Mockito.anyLong());
+		verify(bufferPool).recycle(chunk.data());
 	}
 
 	@Test
@@ -88,6 +89,7 @@ public class ChunkSaverTest {
 
 		verify(chunkIO).write(argThat(contains(ciphertext.get())), eq(expectedPosition));
 		verify(stats).addBytesEncrypted(Mockito.anyLong());
+		verify(bufferPool).recycle(chunk.data());
 	}
 
 	@Test
@@ -99,6 +101,7 @@ public class ChunkSaverTest {
 
 		verifyNoInteractions(chunkIO);
 		verifyNoInteractions(stats);
+		verifyNoInteractions(bufferPool);
 	}
 
 	@Test
@@ -119,6 +122,7 @@ public class ChunkSaverTest {
 		inTest.save(chunkIndex, chunk);
 
 		verify(exceptionsDuringWrite).add(ioException);
+		verify(bufferPool).recycle(chunk.data());
 	}
 
 }

--- a/src/test/java/org/cryptomator/cryptofs/fh/ChunkSaverTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/fh/ChunkSaverTest.java
@@ -1,6 +1,7 @@
 package org.cryptomator.cryptofs.fh;
 
 import org.cryptomator.cryptofs.CryptoFileSystemStats;
+import org.cryptomator.cryptofs.matchers.ByteBufferMatcher;
 import org.cryptomator.cryptolib.api.Cryptor;
 import org.cryptomator.cryptolib.api.FileContentCryptor;
 import org.cryptomator.cryptolib.api.FileHeader;
@@ -69,7 +70,7 @@ public class ChunkSaverTest {
 
 		verify(chunkIO).write(argThat(contains(ciphertext.get())), eq(expectedPosition));
 		verify(stats).addBytesEncrypted(Mockito.anyLong());
-		verify(bufferPool).recycle(chunk.data());
+		verify(bufferPool).recycle(argThat(ByteBufferMatcher.hasCapacity(CIPHERTEXT_CHUNK_SIZE)));
 	}
 
 	@Test
@@ -89,7 +90,7 @@ public class ChunkSaverTest {
 
 		verify(chunkIO).write(argThat(contains(ciphertext.get())), eq(expectedPosition));
 		verify(stats).addBytesEncrypted(Mockito.anyLong());
-		verify(bufferPool).recycle(chunk.data());
+		verify(bufferPool).recycle(argThat(ByteBufferMatcher.hasCapacity(CIPHERTEXT_CHUNK_SIZE)));
 	}
 
 	@Test
@@ -122,7 +123,7 @@ public class ChunkSaverTest {
 		inTest.save(chunkIndex, chunk);
 
 		verify(exceptionsDuringWrite).add(ioException);
-		verify(bufferPool).recycle(chunk.data());
+		verify(bufferPool).recycle(argThat(ByteBufferMatcher.hasCapacity(CIPHERTEXT_CHUNK_SIZE)));
 	}
 
 }

--- a/src/test/java/org/cryptomator/cryptofs/fh/ChunkSaverTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/fh/ChunkSaverTest.java
@@ -58,14 +58,14 @@ public class ChunkSaverTest {
 		long expectedPosition = HEADER_SIZE + chunkIndex * CIPHERTEXT_CHUNK_SIZE;
 		Supplier<ByteBuffer> cleartext = () -> repeat(42).times(CLEARTEXT_CHUNK_SIZE).asByteBuffer();
 		Supplier<ByteBuffer> ciphertext = () -> repeat(50).times(CIPHERTEXT_CHUNK_SIZE).asByteBuffer();
-		ChunkData chunkData = new ChunkData(cleartext.get(), true);
+		Chunk chunk = new Chunk(cleartext.get(), true);
 		doAnswer(invocation -> {
 			ByteBuffer ciphertextBuf = invocation.getArgument(1);
 			ciphertextBuf.put(ciphertext.get());
 			return null;
 		}).when(fileContentCryptor).encryptChunk(argThat(contains(cleartext.get())), Mockito.any(), eq(chunkIndex), eq(header));
 
-		inTest.save(chunkIndex, chunkData);
+		inTest.save(chunkIndex, chunk);
 
 		verify(chunkIO).write(argThat(contains(ciphertext.get())), eq(expectedPosition));
 		verify(stats).addBytesEncrypted(Mockito.anyLong());
@@ -77,14 +77,14 @@ public class ChunkSaverTest {
 		long expectedPosition = HEADER_SIZE + chunkIndex * CIPHERTEXT_CHUNK_SIZE;
 		Supplier<ByteBuffer> cleartext = () -> repeat(42).times(CLEARTEXT_CHUNK_SIZE - 10).asByteBuffer();
 		Supplier<ByteBuffer> ciphertext = () -> repeat(50).times(CIPHERTEXT_CHUNK_SIZE - 10).asByteBuffer();
-		ChunkData chunkData = new ChunkData(cleartext.get(), true);
+		Chunk chunk = new Chunk(cleartext.get(), true);
 		doAnswer(invocation -> {
 			ByteBuffer ciphertextBuf = invocation.getArgument(1);
 			ciphertextBuf.put(ciphertext.get());
 			return null;
 		}).when(fileContentCryptor).encryptChunk(argThat(contains(cleartext.get())), Mockito.any(), eq(chunkIndex), eq(header));
 
-		inTest.save(chunkIndex, chunkData);
+		inTest.save(chunkIndex, chunk);
 
 		verify(chunkIO).write(argThat(contains(ciphertext.get())), eq(expectedPosition));
 		verify(stats).addBytesEncrypted(Mockito.anyLong());
@@ -93,9 +93,9 @@ public class ChunkSaverTest {
 	@Test
 	public void testChunkThatWasNotWrittenIsNotWritten() throws IOException {
 		Long chunkIndex = 43L;
-		ChunkData chunkData = new ChunkData(ByteBuffer.allocate(CLEARTEXT_CHUNK_SIZE), false);
+		Chunk chunk = new Chunk(ByteBuffer.allocate(CLEARTEXT_CHUNK_SIZE), false);
 
-		inTest.save(chunkIndex, chunkData);
+		inTest.save(chunkIndex, chunk);
 
 		verifyNoInteractions(chunkIO);
 		verifyNoInteractions(stats);
@@ -108,7 +108,7 @@ public class ChunkSaverTest {
 		long expectedPosition = HEADER_SIZE + chunkIndex * CIPHERTEXT_CHUNK_SIZE;
 		Supplier<ByteBuffer> cleartext = () -> repeat(42).times(CLEARTEXT_CHUNK_SIZE).asByteBuffer();
 		Supplier<ByteBuffer> ciphertext = () -> repeat(50).times(CIPHERTEXT_CHUNK_SIZE).asByteBuffer();
-		ChunkData chunkData = new ChunkData(cleartext.get(), true);
+		Chunk chunk = new Chunk(cleartext.get(), true);
 		doAnswer(invocation -> {
 			ByteBuffer ciphertextBuf = invocation.getArgument(1);
 			ciphertextBuf.put(ciphertext.get());
@@ -116,7 +116,7 @@ public class ChunkSaverTest {
 		}).when(fileContentCryptor).encryptChunk(argThat(contains(cleartext.get())), Mockito.any(), eq(chunkIndex), eq(header));
 		when(chunkIO.write(argThat(contains(ciphertext.get())), eq(expectedPosition))).thenThrow(ioException);
 
-		inTest.save(chunkIndex, chunkData);
+		inTest.save(chunkIndex, chunk);
 
 		verify(exceptionsDuringWrite).add(ioException);
 	}

--- a/src/test/java/org/cryptomator/cryptofs/fh/ChunkTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/fh/ChunkTest.java
@@ -13,13 +13,13 @@ import java.util.concurrent.atomic.LongAdder;
 
 import static org.cryptomator.cryptofs.util.ByteBuffers.repeat;
 
-public class ChunkDataTest {
+public class ChunkTest {
 
 	@Test
 	public void testChunkDataWrappingBufferIsNotDirty() {
 		ByteBuffer buffer = repeat(3).times(200).asByteBuffer();
 
-		ChunkData inTest = new ChunkData(buffer, false);
+		Chunk inTest = new Chunk(buffer, false);
 
 		Assertions.assertFalse(inTest.isDirty());
 	}
@@ -28,7 +28,7 @@ public class ChunkDataTest {
 	public void testEmptyChunkDataIsNotDirty() {
 		ByteBuffer buffer = ByteBuffer.allocate(0);
 
-		ChunkData inTest = new ChunkData(buffer, false);
+		Chunk inTest = new Chunk(buffer, false);
 
 		Assertions.assertFalse(inTest.isDirty());
 	}
@@ -37,7 +37,7 @@ public class ChunkDataTest {
 	public void testToString() {
 		ByteBuffer buffer = ByteBuffer.allocate(100);
 
-		ChunkData inTest = new ChunkData(buffer, true);
+		Chunk inTest = new Chunk(buffer, true);
 
 		Assertions.assertEquals("ChunkData(dirty: true, length: 100)", inTest.toString());
 	}
@@ -45,7 +45,7 @@ public class ChunkDataTest {
 	@Test // https://github.com/cryptomator/cryptofs/issues/85
 	public void testRaceConditionsDuringRead() {
 		ByteBuffer src = StandardCharsets.US_ASCII.encode("abcdefg");
-		ChunkData inTest = new ChunkData(src, false);
+		Chunk inTest = new Chunk(src, false);
 		int attempts = 4000;
 		int threads = 6;
 

--- a/src/test/java/org/cryptomator/cryptofs/fh/ChunkTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/fh/ChunkTest.java
@@ -33,15 +33,6 @@ public class ChunkTest {
 		Assertions.assertFalse(inTest.isDirty());
 	}
 
-	@Test
-	public void testToString() {
-		ByteBuffer buffer = ByteBuffer.allocate(100);
-
-		Chunk inTest = new Chunk(buffer, true);
-
-		Assertions.assertEquals("ChunkData(dirty: true, length: 100)", inTest.toString());
-	}
-
 	@Test // https://github.com/cryptomator/cryptofs/issues/85
 	public void testRaceConditionsDuringRead() {
 		ByteBuffer src = StandardCharsets.US_ASCII.encode("abcdefg");

--- a/src/test/java/org/cryptomator/cryptofs/matchers/ByteBufferMatcher.java
+++ b/src/test/java/org/cryptomator/cryptofs/matchers/ByteBufferMatcher.java
@@ -19,6 +19,10 @@ public class ByteBufferMatcher {
 		return matcher("bytes remaining", is(remaining), ByteBuffer::remaining);
 	}
 
+	public static Matcher<ByteBuffer> hasCapacity(int capacity) {
+		return matcher("capacity", is(capacity), ByteBuffer::capacity);
+	}
+
 	public static Matcher<ByteBuffer> contains(ByteBuffer data) {
 		byte[] arrayData = new byte[data.remaining()];
 		data.get(arrayData);


### PR DESCRIPTION
Previously, each chunk of data allocated a new 32kB ByteBuffer, which was in most cases very short-lived. This lead to both, massive allocations as well as garbage collection activity.

To reduce both memory as well as CPU pressure, this introduces a filesystem-scoped pooling mechanism. ByteBuffers _should_ be returned to the pool but it will do no harm not to do so.