### PR TITLE
Use dirid file in orphan dir fix

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/DirectoryIdBackup.java
+++ b/src/main/java/org/cryptomator/cryptofs/DirectoryIdBackup.java
@@ -40,6 +40,18 @@ public class DirectoryIdBackup {
 		}
 	}
 
+	/**
+	 * Static method to explicitly backup the directory id for a specified ciphertext directory.
+	 *
+	 * @param cryptor The cryptor to be used
+	 * @param ciphertextDirectory A {@link org.cryptomator.cryptofs.CryptoPathMapper.CiphertextDirectory} for which the dirId should be back up'd.
+	 * @throws IOException when the dirId file already exists, or it cannot be written to.
+	 */
+	public static void backupManually(Cryptor cryptor, CryptoPathMapper.CiphertextDirectory ciphertextDirectory) throws IOException {
+		new DirectoryIdBackup(cryptor).execute(ciphertextDirectory);
+	}
+
+
 	static EncryptingWritableByteChannel wrapEncryptionAround(ByteChannel channel, Cryptor cryptor) {
 		return new EncryptingWritableByteChannel(channel, cryptor);
 	}

--- a/src/main/java/org/cryptomator/cryptofs/DirectoryIdBackup.java
+++ b/src/main/java/org/cryptomator/cryptofs/DirectoryIdBackup.java
@@ -36,7 +36,7 @@ public class DirectoryIdBackup {
 	public void execute(CryptoPathMapper.CiphertextDirectory ciphertextDirectory) throws IOException {
 		try (var channel = Files.newByteChannel(ciphertextDirectory.path.resolve(Constants.DIR_ID_FILE), StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE); //
 			 var encryptingChannel = wrapEncryptionAround(channel, cryptor)) {
-			encryptingChannel.write(ByteBuffer.wrap(ciphertextDirectory.dirId.getBytes(StandardCharsets.UTF_8)));
+			encryptingChannel.write(ByteBuffer.wrap(ciphertextDirectory.dirId.getBytes(StandardCharsets.US_ASCII)));
 		}
 	}
 

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
@@ -161,7 +161,7 @@ public class OrphanDir implements DiagnosticResult {
 	//visible for testing
 	Optional<String> retrieveDirId(Path orphanedDir, Cryptor cryptor) {
 		var dirIdFile = orphanedDir.resolve(Constants.DIR_ID_FILE);
-		var dirIdBuffer = ByteBuffer.allocate(36); //a dir id contains at most 36 ascii chars, in this impl encoded in utf8
+		var dirIdBuffer = ByteBuffer.allocate(36); //a dir id contains at most 36 ascii chars
 
 		try (var channel = Files.newByteChannel(dirIdFile, StandardOpenOption.READ); //
 			 var decryptingChannel = createDecryptingReadableByteChannel(channel, cryptor)) {
@@ -172,7 +172,7 @@ public class OrphanDir implements DiagnosticResult {
 			return Optional.empty();
 		}
 
-		var allegedDirId = StandardCharsets.UTF_8.decode(dirIdBuffer).toString();
+		var allegedDirId = StandardCharsets.US_ASCII.decode(dirIdBuffer).toString();
 
 		var dirIdHash = orphanedDir.getParent().getFileName().toString() + orphanedDir.getFileName().toString();
 		if (dirIdHash.equals(cryptor.fileNameCryptor().hashDirectoryId(allegedDirId))) {

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
@@ -10,6 +10,7 @@ import org.cryptomator.cryptolib.api.AuthenticationFailedException;
 import org.cryptomator.cryptolib.api.Cryptor;
 import org.cryptomator.cryptolib.api.FileNameCryptor;
 import org.cryptomator.cryptolib.api.Masterkey;
+import org.cryptomator.cryptolib.common.ByteBuffers;
 import org.cryptomator.cryptolib.common.DecryptingReadableByteChannel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -164,7 +165,7 @@ public class OrphanDir implements DiagnosticResult {
 
 		try (var channel = Files.newByteChannel(dirIdFile, StandardOpenOption.READ); //
 			 var decryptingChannel = createDecryptingReadableByteChannel(channel, cryptor)) {
-			decryptingChannel.read(dirIdBuffer);
+			ByteBuffers.fill(decryptingChannel, dirIdBuffer);
 			dirIdBuffer.flip();
 		} catch (IOException e) {
 			LOG.info("Unable to read dirIdFile of {}.", orphanedDir, e);

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanDir.java
@@ -109,9 +109,7 @@ public class OrphanDir implements DiagnosticResult {
 			}
 		}
 
-		if (dirId.isPresent()) {
-			Files.delete(orphanedDir.resolve(Constants.DIR_ID_FILE));
-		}
+		Files.deleteIfExists(orphanedDir.resolve(Constants.DIR_ID_FILE));
 		Files.delete(orphanedDir);
 	}
 

--- a/src/test/java/org/cryptomator/cryptofs/DirectoryIdBackupTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/DirectoryIdBackupTest.java
@@ -53,7 +53,7 @@ public class DirectoryIdBackupTest {
 	@Test
 	public void testContentIsWritten() throws IOException {
 		Mockito.when(encChannel.write(Mockito.any())).thenReturn(0);
-		var expectedWrittenContent = ByteBuffer.wrap(dirId.getBytes(StandardCharsets.UTF_8));
+		var expectedWrittenContent = ByteBuffer.wrap(dirId.getBytes(StandardCharsets.US_ASCII));
 
 		try (MockedStatic<DirectoryIdBackup> backupMock = Mockito.mockStatic(DirectoryIdBackup.class)) {
 			backupMock.when(() -> DirectoryIdBackup.wrapEncryptionAround(Mockito.any(), Mockito.eq(cryptor))).thenReturn(encChannel);

--- a/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
@@ -223,7 +223,7 @@ public class OrphanDirTest {
 			var dirIdFile = cipherOrphan.resolve(Constants.DIR_ID_FILE);
 			var dirId = "random-uuid-with-at-most-36chars";
 
-			Files.writeString(dirIdFile, dirId, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+			Files.writeString(dirIdFile, dirId, StandardCharsets.US_ASCII, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
 			DecryptingReadableByteChannel dirIdReadChannel = Mockito.mock(DecryptingReadableByteChannel.class);
 
 			Mockito.doReturn(dirIdReadChannel).when(resultSpy).createDecryptingReadableByteChannel(Mockito.any(), Mockito.eq(cryptor));
@@ -260,7 +260,7 @@ public class OrphanDirTest {
 		public void testRetrieveDirIdWrongContent() throws IOException {
 			var dirIdFile = cipherOrphan.resolve(Constants.DIR_ID_FILE);
 			var dirId = "anOverlyComplexAndCompletelyRandomExampleOfHowAnDirectoryIdIsTooLong";
-			Files.writeString(dirIdFile, dirId, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+			Files.writeString(dirIdFile, dirId, StandardCharsets.US_ASCII, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
 			DecryptingReadableByteChannel dirIdReadChannel = Mockito.mock(DecryptingReadableByteChannel.class);
 
 			Mockito.doReturn(dirIdReadChannel).when(resultSpy).createDecryptingReadableByteChannel(Mockito.any(), Mockito.eq(cryptor));

--- a/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
@@ -7,6 +7,7 @@ import org.cryptomator.cryptofs.common.Constants;
 import org.cryptomator.cryptolib.api.Cryptor;
 import org.cryptomator.cryptolib.api.FileNameCryptor;
 import org.cryptomator.cryptolib.api.Masterkey;
+import org.cryptomator.cryptolib.common.EncryptingReadableByteChannel;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
@@ -35,7 +37,8 @@ public class OrphanDirTest {
 	private Path cipherRoot;
 	private Path cipherRecovery;
 	private Path cipherOrphan;
-	private FileNameCryptor cryptor;
+	private Cryptor cryptor;
+	private FileNameCryptor fileNameCryptor;
 
 	@BeforeEach
 	public void init() throws IOException {
@@ -49,7 +52,9 @@ public class OrphanDirTest {
 		Files.createDirectories(cipherRoot);
 		Files.createDirectories(cipherOrphan);
 
-		cryptor = Mockito.mock(FileNameCryptor.class);
+		cryptor = Mockito.mock(Cryptor.class);
+		Mockito.doReturn(fileNameCryptor).when(cryptor).fileNameCryptor();
+		fileNameCryptor = Mockito.mock(FileNameCryptor.class);
 	}
 
 
@@ -58,18 +63,18 @@ public class OrphanDirTest {
 
 		@BeforeEach
 		public void init() {
-			Mockito.doReturn("000000").when(cryptor).hashDirectoryId(Constants.ROOT_DIR_ID);
-			Mockito.doReturn("111111").when(cryptor).hashDirectoryId(Constants.RECOVERY_DIR_ID);
-			Mockito.doReturn("222222").when(cryptor).hashDirectoryId("aaaaaa");
+			Mockito.doReturn("000000").when(fileNameCryptor).hashDirectoryId(Constants.ROOT_DIR_ID);
+			Mockito.doReturn("111111").when(fileNameCryptor).hashDirectoryId(Constants.RECOVERY_DIR_ID);
+			Mockito.doReturn("222222").when(fileNameCryptor).hashDirectoryId("aaaaaa");
 
-			Mockito.doReturn("1").when(cryptor).encryptFilename(BaseEncoding.base64Url(), Constants.RECOVERY_DIR_NAME, Constants.ROOT_DIR_ID.getBytes(StandardCharsets.UTF_8));
+			Mockito.doReturn("1").when(fileNameCryptor).encryptFilename(BaseEncoding.base64Url(), Constants.RECOVERY_DIR_NAME, Constants.ROOT_DIR_ID.getBytes(StandardCharsets.UTF_8));
 		}
 
 
 		@Test
 		@DisplayName("prepareRecoveryDir() creates recovery dir if not existent")
 		public void testPrepareStepParentNonExistingRecoveryDir() throws IOException {
-			Path actualCipherDir = result.prepareRecoveryDir(pathToVault, cryptor);
+			Path actualCipherDir = result.prepareRecoveryDir(pathToVault, fileNameCryptor);
 
 			Assertions.assertEquals(cipherRecovery, actualCipherDir);
 			Assertions.assertEquals(Constants.RECOVERY_DIR_ID, Files.readString(pathToVault.resolve("d/00/0000/1.c9r/dir.c9r"), StandardCharsets.UTF_8));
@@ -85,7 +90,7 @@ public class OrphanDirTest {
 			Files.writeString(existingRecoveryDirFile, Constants.RECOVERY_DIR_ID, StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
 			Files.createDirectories(cipherRecovery);
 
-			Path actualCipherDir = result.prepareRecoveryDir(pathToVault, cryptor);
+			Path actualCipherDir = result.prepareRecoveryDir(pathToVault, fileNameCryptor);
 
 			Assertions.assertEquals(cipherRecovery, actualCipherDir);
 			Assertions.assertEquals(Constants.RECOVERY_DIR_ID, Files.readString(pathToVault.resolve("d/00/0000/1.c9r/dir.c9r"), StandardCharsets.UTF_8));
@@ -100,7 +105,7 @@ public class OrphanDirTest {
 			Files.createDirectories(missingRecoveryDirFile.getParent());
 			Files.createDirectories(cipherRecovery);
 
-			Path actualCipherDir = result.prepareRecoveryDir(pathToVault, cryptor);
+			Path actualCipherDir = result.prepareRecoveryDir(pathToVault, fileNameCryptor);
 
 			Assertions.assertEquals(cipherRecovery, actualCipherDir);
 			Assertions.assertEquals(Constants.RECOVERY_DIR_ID, Files.readString(pathToVault.resolve("d/00/0000/1.c9r/dir.c9r"), StandardCharsets.UTF_8));
@@ -115,7 +120,7 @@ public class OrphanDirTest {
 			Files.createDirectories(existingRecoveryDirFile.getParent());
 			Files.writeString(existingRecoveryDirFile, UUID.randomUUID().toString(), StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
 
-			Assertions.assertThrows(FileAlreadyExistsException.class, () -> result.prepareRecoveryDir(pathToVault, cryptor));
+			Assertions.assertThrows(FileAlreadyExistsException.class, () -> result.prepareRecoveryDir(pathToVault, fileNameCryptor));
 
 			Assertions.assertNotEquals(Constants.RECOVERY_DIR_ID, Files.readString(existingRecoveryDirFile, StandardCharsets.UTF_8));
 		}
@@ -132,9 +137,9 @@ public class OrphanDirTest {
 			clearStepParentName = "step-parent";
 			Files.createDirectories(cipherRecovery);
 
-			Mockito.doReturn("222222").when(cryptor).hashDirectoryId("aaaaaa");
-			Mockito.doReturn("1").when(cryptor).encryptFilename(BaseEncoding.base64Url(), Constants.RECOVERY_DIR_NAME, Constants.ROOT_DIR_ID.getBytes(StandardCharsets.UTF_8));
-			Mockito.doReturn("2").when(cryptor).encryptFilename(BaseEncoding.base64Url(), clearStepParentName, Constants.RECOVERY_DIR_ID.getBytes(StandardCharsets.UTF_8));
+			Mockito.doReturn("222222").when(fileNameCryptor).hashDirectoryId("aaaaaa");
+			Mockito.doReturn("1").when(fileNameCryptor).encryptFilename(BaseEncoding.base64Url(), Constants.RECOVERY_DIR_NAME, Constants.ROOT_DIR_ID.getBytes(StandardCharsets.UTF_8));
+			Mockito.doReturn("2").when(fileNameCryptor).encryptFilename(BaseEncoding.base64Url(), clearStepParentName, Constants.RECOVERY_DIR_ID.getBytes(StandardCharsets.UTF_8));
 		}
 
 		@Test
@@ -145,7 +150,7 @@ public class OrphanDirTest {
 				uuidClass.when(() -> UUID.randomUUID()).thenReturn(uuid);
 				Mockito.doReturn("aaaaaa").when(uuid).toString();
 
-				result.prepareStepParent(dataDir, cipherRecovery, cryptor, clearStepParentName);
+				result.prepareStepParent(dataDir, cipherRecovery, fileNameCryptor, clearStepParentName);
 			}
 
 			Assertions.assertEquals("aaaaaa", Files.readString(cipherRecovery.resolve("2.c9r/dir.c9r"), StandardCharsets.UTF_8));
@@ -166,7 +171,7 @@ public class OrphanDirTest {
 				uuidClass.when(() -> UUID.randomUUID()).thenReturn(uuid);
 				Mockito.doReturn("aaaaaa").when(uuid).toString();
 
-				result.prepareStepParent(dataDir, cipherRecovery, cryptor, clearStepParentName);
+				result.prepareStepParent(dataDir, cipherRecovery, fileNameCryptor, clearStepParentName);
 			}
 
 			Assertions.assertEquals("aaaaaa", Files.readString(cipherRecovery.resolve("2.c9r/dir.c9r"), StandardCharsets.UTF_8));
@@ -187,13 +192,124 @@ public class OrphanDirTest {
 				uuidClass.when(() -> UUID.randomUUID()).thenReturn(uuid);
 				Mockito.doReturn("aaaaaa").when(uuid).toString();
 
-				result.prepareStepParent(dataDir, cipherRecovery, cryptor, clearStepParentName);
+				result.prepareStepParent(dataDir, cipherRecovery, fileNameCryptor, clearStepParentName);
 			}
 
 			Assertions.assertEquals("aaaaaa", Files.readString(cipherRecovery.resolve("2.c9r/dir.c9r"), StandardCharsets.UTF_8));
 			Assertions.assertTrue(Files.isDirectory(pathToVault.resolve("d/22/2222")));
 		}
 	}
+
+
+	@Nested
+	class RestoreFilenameTests {
+
+		@Test
+		@DisplayName("restoring filename of not-shortened resource is successful")
+		void testRestoreFilenameNormalSuccess() throws IOException {
+			Path oldCipherPath = cipherOrphan.resolve("orphan.c9r");
+			Files.createFile(oldCipherPath);
+			//by using Mockito.eq() in filename parameter Mockito.verfiy() not necessary
+			Mockito.when(fileNameCryptor.decryptFilename(Mockito.any(), Mockito.eq("orphan"), Mockito.any())).thenReturn("theTrueName.txt");
+
+			String decryptedFile = result.restoreFileName(oldCipherPath, false, "someDirId", fileNameCryptor);
+
+			Assertions.assertEquals("theTrueName.txt", decryptedFile);
+		}
+
+		@Test
+		@DisplayName("restoring filename of shortened resource is successful")
+		void testRestoreFilenameShortenedSuccess() throws IOException {
+			String inflatedEncryptedName = "OrphanWithLongestName.c9r";
+			Path oldCipherPath = cipherOrphan.resolve("hashOfOrphanWithLongestName.c9r");
+			Path oldCipherPathNameFile = oldCipherPath.resolve(Constants.INFLATED_FILE_NAME);
+			Files.createDirectory(oldCipherPath);
+			Files.writeString(oldCipherPathNameFile, inflatedEncryptedName);
+			//by using Mockito.eq() in filename parameter Mockito.verfiy() not necessary
+			Mockito.when(fileNameCryptor.decryptFilename(Mockito.any(), Mockito.eq("OrphanWithLongestName"), Mockito.any())).thenReturn("theRealLongName.txt");
+
+			String decryptedFile = result.restoreFileName(oldCipherPath, true, "someDirId", fileNameCryptor);
+
+			Assertions.assertEquals("theRealLongName.txt", decryptedFile);
+		}
+
+		@Test
+		@DisplayName("restoreFilename with shortened resource throws IO exception when name.c9s cannot be read")
+		void testRestoreFilenameShortenedIOException() throws IOException {
+			Path oldCipherPath = cipherOrphan.resolve("hashOfOrphanWithLongestName.c9r");
+			Files.createDirectory(oldCipherPath);
+
+			Assertions.assertThrows(IOException.class, () -> result.restoreFileName(oldCipherPath, true, "someDirId", fileNameCryptor));
+		}
+	}
+
+
+	@Nested
+	class RetrieveDirIdTests {
+
+		private OrphanDir resultSpy;
+
+		@BeforeEach
+		public void init() {
+			resultSpy = Mockito.spy(result);
+			Mockito.doReturn(fileNameCryptor).when(cryptor).fileNameCryptor();
+		}
+
+		@Test
+		@DisplayName("retrieveDirId extracts directory id of cipher-dir/dirId.c9r")
+		public void testRetrieveDirIdSuccess() throws IOException {
+			var dirIdFile = cipherOrphan.resolve(Constants.DIR_ID_FILE);
+			var dirId = "random-uuid-with-at-most-36chars";
+			Files.writeString(dirIdFile, dirId, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+			EncryptingReadableByteChannel dirIdReadChannel = Mockito.mock(EncryptingReadableByteChannel.class);
+
+			Mockito.doReturn(dirIdReadChannel).when(resultSpy).wrapDecryptionAround(Mockito.any(), Mockito.eq(cryptor));
+			Mockito.doAnswer(invocationOnMock -> {
+				try (ReadableByteChannel channel = Files.newByteChannel(dirIdFile, StandardOpenOption.READ)) {
+					return channel.read(invocationOnMock.getArgument(0));
+				}
+			}).when(dirIdReadChannel).read(Mockito.any());
+
+			Mockito.when(fileNameCryptor.hashDirectoryId(Mockito.eq(dirId))).thenReturn("333333");
+
+			var maybeDirId = resultSpy.retrieveDirId(cipherOrphan, cryptor);
+
+			Assertions.assertTrue(maybeDirId.isPresent());
+			Assertions.assertEquals(dirId, maybeDirId.get());
+		}
+
+		@Test
+		@DisplayName("retrieveDirId returns an empty optional if cipher-dir/dirId.c9r cannot be read")
+		public void testRetrieveDirIdIOExceptionReadingFile() throws IOException {
+			var notExistingResult = resultSpy.retrieveDirId(cipherOrphan, cryptor);
+
+			Assertions.assertTrue(notExistingResult.isEmpty());
+		}
+
+
+		@Test
+		@DisplayName("retrieveDirId returns empty optional if content of dirId.c9r does not match cipher dir hash")
+		public void testRetrieveDirIdWrongContent() throws IOException {
+			var dirIdFile = cipherOrphan.resolve(Constants.DIR_ID_FILE);
+			var dirId = "anOverlyComplexAndCompletelyRandomExampleOfHowAnDirectoryIdIsTooLong";
+			Files.writeString(dirIdFile, dirId, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+			EncryptingReadableByteChannel dirIdReadChannel = Mockito.mock(EncryptingReadableByteChannel.class);
+
+			Mockito.doReturn(dirIdReadChannel).when(resultSpy).wrapDecryptionAround(Mockito.any(), Mockito.eq(cryptor));
+			Mockito.doAnswer(invocationOnMock -> {
+				try (ReadableByteChannel channel = Files.newByteChannel(dirIdFile, StandardOpenOption.READ)) {
+					return channel.read(invocationOnMock.getArgument(0));
+				}
+			}).when(dirIdReadChannel).read(Mockito.any());
+			Mockito.when(fileNameCryptor.hashDirectoryId(Mockito.eq(dirId.substring(0, 36)))).thenReturn("123456");
+
+			var maybeDirId = resultSpy.retrieveDirId(cipherOrphan, cryptor);
+
+			Assertions.assertTrue(maybeDirId.isEmpty());
+		}
+
+	}
+
 
 	@Nested
 	class AdoptOrphanedTests {
@@ -209,10 +325,10 @@ public class OrphanDirTest {
 			CryptoPathMapper.CiphertextDirectory stepParentDir = new CryptoPathMapper.CiphertextDirectory("aaaaaa", pathToVault.resolve("d/22/2222"));
 			Files.createDirectories(stepParentDir.path);
 
-			Mockito.doReturn("adopted").when(cryptor).encryptFilename(BaseEncoding.base64Url(), newClearName, stepParentDir.dirId.getBytes(StandardCharsets.UTF_8));
+			Mockito.doReturn("adopted").when(fileNameCryptor).encryptFilename(BaseEncoding.base64Url(), newClearName, stepParentDir.dirId.getBytes(StandardCharsets.UTF_8));
 			var sha1 = Mockito.mock(MessageDigest.class);
 
-			result.adoptOrphanedResource(oldCipherPath, newClearName, stepParentDir, cryptor, "longNameSuffix", sha1);
+			result.adoptOrphanedResource(oldCipherPath, newClearName, false, stepParentDir, fileNameCryptor, sha1);
 
 			Assertions.assertEquals(expectedMsg, Files.readString(stepParentDir.path.resolve("adopted.c9r")));
 			Assertions.assertTrue(Files.notExists(oldCipherPath));
@@ -230,7 +346,7 @@ public class OrphanDirTest {
 			CryptoPathMapper.CiphertextDirectory stepParentDir = new CryptoPathMapper.CiphertextDirectory("aaaaaa", pathToVault.resolve("d/22/2222"));
 			Files.createDirectories(stepParentDir.path);
 
-			Mockito.doReturn("adopted").when(cryptor).encryptFilename(Mockito.any(), Mockito.any(), Mockito.any());
+			Mockito.doReturn("adopted").when(fileNameCryptor).encryptFilename(Mockito.any(), Mockito.any(), Mockito.any());
 			try (var baseEncodingClass = Mockito.mockStatic(BaseEncoding.class)) {
 				MessageDigest sha1 = Mockito.mock(MessageDigest.class);
 				Mockito.doReturn(new byte[]{}).when(sha1).digest(Mockito.any());
@@ -239,7 +355,7 @@ public class OrphanDirTest {
 				baseEncodingClass.when(() -> BaseEncoding.base64Url()).thenReturn(base64url);
 				Mockito.doReturn("adopted_shortened").when(base64url).encode(Mockito.any());
 
-				result.adoptOrphanedResource(oldCipherPath, newClearName, stepParentDir, cryptor, "", sha1);
+				result.adoptOrphanedResource(oldCipherPath, newClearName, true, stepParentDir, fileNameCryptor, sha1);
 			}
 
 			Assertions.assertTrue(Files.exists(stepParentDir.path.resolve("adopted_shortened.c9s")));
@@ -258,7 +374,7 @@ public class OrphanDirTest {
 			CryptoPathMapper.CiphertextDirectory stepParentDir = new CryptoPathMapper.CiphertextDirectory("aaaaaa", pathToVault.resolve("d/22/2222"));
 			Files.createDirectories(stepParentDir.path);
 
-			Mockito.doReturn("adopted").when(cryptor).encryptFilename(Mockito.any(), Mockito.any(), Mockito.any());
+			Mockito.doReturn("adopted").when(fileNameCryptor).encryptFilename(Mockito.any(), Mockito.any(), Mockito.any());
 			try (var baseEncodingClass = Mockito.mockStatic(BaseEncoding.class)) {
 				MessageDigest sha1 = Mockito.mock(MessageDigest.class);
 				Mockito.doReturn(new byte[]{}).when(sha1).digest(Mockito.any());
@@ -267,7 +383,7 @@ public class OrphanDirTest {
 				baseEncodingClass.when(() -> BaseEncoding.base64Url()).thenReturn(base64url);
 				Mockito.doReturn("adopted_shortened").when(base64url).encode(Mockito.any());
 
-				result.adoptOrphanedResource(oldCipherPath, newClearName, stepParentDir, cryptor, "", sha1);
+				result.adoptOrphanedResource(oldCipherPath, newClearName, true, stepParentDir, fileNameCryptor, sha1);
 			}
 
 			Assertions.assertTrue(Files.exists(stepParentDir.path.resolve("adopted_shortened.c9s")));
@@ -295,18 +411,18 @@ public class OrphanDirTest {
 		Mockito.doReturn(170).when(config).getShorteningThreshold();
 		Masterkey masterkey = Mockito.mock(Masterkey.class);
 		Cryptor generalCryptor = Mockito.mock(Cryptor.class);
-		Mockito.doReturn(cryptor).when(generalCryptor).fileNameCryptor();
+		Mockito.doReturn(fileNameCryptor).when(generalCryptor).fileNameCryptor();
 
-		Mockito.doReturn(cipherRecovery).when(resultSpy).prepareRecoveryDir(pathToVault, cryptor);
-		Mockito.doReturn(stepParentDir).when(resultSpy).prepareStepParent(Mockito.eq(dataDir), Mockito.eq(cipherRecovery), Mockito.eq(cryptor), Mockito.any());
+		Mockito.doReturn(cipherRecovery).when(resultSpy).prepareRecoveryDir(pathToVault, fileNameCryptor);
+		Mockito.doReturn(stepParentDir).when(resultSpy).prepareStepParent(Mockito.eq(dataDir), Mockito.eq(cipherRecovery), Mockito.eq(fileNameCryptor), Mockito.any());
 		Mockito.doAnswer(invocationOnMock -> {
 			Files.delete((Path) invocationOnMock.getArgument(0));
 			return null;
-		}).when(resultSpy).adoptOrphanedResource(Mockito.any(), Mockito.any(), Mockito.eq(stepParentDir), Mockito.eq(cryptor), Mockito.any(), Mockito.any());
+		}).when(resultSpy).adoptOrphanedResource(Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.eq(stepParentDir), Mockito.eq(fileNameCryptor), Mockito.any());
 
 		resultSpy.fix(pathToVault, config, masterkey, generalCryptor);
 
-		Mockito.verify(resultSpy, Mockito.times(2)).adoptOrphanedResource(Mockito.any(), Mockito.any(), Mockito.eq(stepParentDir), Mockito.eq(cryptor), Mockito.any(), Mockito.any());
+		Mockito.verify(resultSpy, Mockito.times(2)).adoptOrphanedResource(Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.eq(stepParentDir), Mockito.eq(fileNameCryptor), Mockito.any());
 		Assertions.assertTrue(Files.notExists(cipherOrphan));
 	}
 
@@ -318,27 +434,27 @@ public class OrphanDirTest {
 		Mockito.doReturn(170).when(config).getShorteningThreshold();
 		Masterkey masterkey = Mockito.mock(Masterkey.class);
 		Cryptor generalCryptor = Mockito.mock(Cryptor.class);
-		Mockito.doReturn(cryptor).when(generalCryptor).fileNameCryptor();
+		Mockito.doReturn(fileNameCryptor).when(generalCryptor).fileNameCryptor();
 
 		AtomicReference<String> clearStepparentNameRef = new AtomicReference<>("");
 
 		var interruptedResult = new OrphanDir(dataDir.relativize(cipherOrphan));
 		var interruptedSpy = Mockito.spy(interruptedResult);
-		Mockito.doReturn(cipherRecovery).when(interruptedSpy).prepareRecoveryDir(pathToVault, cryptor);
+		Mockito.doReturn(cipherRecovery).when(interruptedSpy).prepareRecoveryDir(pathToVault, fileNameCryptor);
 		Mockito.doAnswer(invocation -> {
 			clearStepparentNameRef.set((String) invocation.getArgument(3));
 			throw new IOException("Interrupt");
-		}).when(interruptedSpy).prepareStepParent(Mockito.eq(dataDir), Mockito.eq(cipherRecovery), Mockito.eq(cryptor), Mockito.any());
+		}).when(interruptedSpy).prepareStepParent(Mockito.eq(dataDir), Mockito.eq(cipherRecovery), Mockito.eq(fileNameCryptor), Mockito.any());
 
 		var continuedResult = new OrphanDir(dataDir.relativize(cipherOrphan));
 		var continuedSpy = Mockito.spy(continuedResult);
-		Mockito.doReturn(cipherRecovery).when(continuedSpy).prepareRecoveryDir(pathToVault, cryptor);
+		Mockito.doReturn(cipherRecovery).when(continuedSpy).prepareRecoveryDir(pathToVault, fileNameCryptor);
 		Mockito.doThrow(IOException.class).when(continuedSpy).prepareStepParent(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
 
 		Assertions.assertThrows(IOException.class, () -> interruptedSpy.fix(pathToVault, config, masterkey, generalCryptor));
 		Assertions.assertThrows(IOException.class, () -> continuedSpy.fix(pathToVault, config, masterkey, generalCryptor));
 
-		Mockito.verify(continuedSpy).prepareStepParent(dataDir, cipherRecovery, cryptor, clearStepparentNameRef.get());
+		Mockito.verify(continuedSpy).prepareStepParent(dataDir, cipherRecovery, fileNameCryptor, clearStepparentNameRef.get());
 	}
 
 
@@ -359,13 +475,16 @@ public class OrphanDirTest {
 		Mockito.doReturn(170).when(config).getShorteningThreshold();
 		Masterkey masterkey = Mockito.mock(Masterkey.class);
 		Cryptor generalCryptor = Mockito.mock(Cryptor.class);
-		Mockito.doReturn(cryptor).when(generalCryptor).fileNameCryptor();
-		Mockito.doReturn(cipherRecovery).when(resultSpy).prepareRecoveryDir(pathToVault, cryptor);
+		Mockito.doReturn(fileNameCryptor).when(generalCryptor).fileNameCryptor();
+		Mockito.doReturn(cipherRecovery).when(resultSpy).prepareRecoveryDir(pathToVault, fileNameCryptor);
 
 		resultSpy.fix(pathToVault, config, masterkey, generalCryptor);
 
-		Mockito.verify(resultSpy, Mockito.never()).prepareStepParent(Mockito.eq(dataDir), Mockito.eq(cipherRecovery), Mockito.eq(cryptor), Mockito.any());
-		Mockito.verify(resultSpy, Mockito.never()).adoptOrphanedResource(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.eq(cryptor), Mockito.any(), Mockito.any());
-		Mockito.verify(resultSpy).prepareRecoveryDir(pathToVault, cryptor);
+		Mockito.verify(resultSpy, Mockito.never()).prepareStepParent(Mockito.eq(dataDir), Mockito.eq(cipherRecovery), Mockito.eq(fileNameCryptor), Mockito.any());
+		Mockito.verify(resultSpy, Mockito.never()).adoptOrphanedResource(Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.any(), Mockito.eq(fileNameCryptor), Mockito.any());
+		Mockito.verify(resultSpy).prepareRecoveryDir(pathToVault, fileNameCryptor);
 	}
+
+
+	//TODO: write tests when dirId exists
 }

--- a/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
@@ -53,8 +53,9 @@ public class OrphanDirTest {
 		Files.createDirectories(cipherOrphan);
 
 		cryptor = Mockito.mock(Cryptor.class);
-		Mockito.doReturn(fileNameCryptor).when(cryptor).fileNameCryptor();
 		fileNameCryptor = Mockito.mock(FileNameCryptor.class);
+		Mockito.doReturn(fileNameCryptor).when(cryptor).fileNameCryptor();
+		Mockito.doReturn(fileNameCryptor).when(cryptor).fileNameCryptor();
 	}
 
 
@@ -147,7 +148,7 @@ public class OrphanDirTest {
 		public void testPrepareStepParent() throws IOException {
 			try (var uuidClass = Mockito.mockStatic(UUID.class)) {
 				UUID uuid = Mockito.mock(UUID.class);
-				uuidClass.when(() -> UUID.randomUUID()).thenReturn(uuid);
+				uuidClass.when(UUID::randomUUID).thenReturn(uuid);
 				Mockito.doReturn("aaaaaa").when(uuid).toString();
 
 				result.prepareStepParent(dataDir, cipherRecovery, fileNameCryptor, clearStepParentName);
@@ -168,7 +169,7 @@ public class OrphanDirTest {
 
 			try (var uuidClass = Mockito.mockStatic(UUID.class)) {
 				UUID uuid = Mockito.mock(UUID.class);
-				uuidClass.when(() -> UUID.randomUUID()).thenReturn(uuid);
+				uuidClass.when(UUID::randomUUID).thenReturn(uuid);
 				Mockito.doReturn("aaaaaa").when(uuid).toString();
 
 				result.prepareStepParent(dataDir, cipherRecovery, fileNameCryptor, clearStepParentName);
@@ -189,7 +190,7 @@ public class OrphanDirTest {
 
 			try (var uuidClass = Mockito.mockStatic(UUID.class)) {
 				UUID uuid = Mockito.mock(UUID.class);
-				uuidClass.when(() -> UUID.randomUUID()).thenReturn(uuid);
+				uuidClass.when(UUID::randomUUID).thenReturn(uuid);
 				Mockito.doReturn("aaaaaa").when(uuid).toString();
 
 				result.prepareStepParent(dataDir, cipherRecovery, fileNameCryptor, clearStepParentName);
@@ -202,49 +203,6 @@ public class OrphanDirTest {
 
 
 	@Nested
-	class RestoreFilenameTests {
-
-		@Test
-		@DisplayName("restoring filename of not-shortened resource is successful")
-		void testRestoreFilenameNormalSuccess() throws IOException {
-			Path oldCipherPath = cipherOrphan.resolve("orphan.c9r");
-			Files.createFile(oldCipherPath);
-			//by using Mockito.eq() in filename parameter Mockito.verfiy() not necessary
-			Mockito.when(fileNameCryptor.decryptFilename(Mockito.any(), Mockito.eq("orphan"), Mockito.any())).thenReturn("theTrueName.txt");
-
-			String decryptedFile = result.restoreFileName(oldCipherPath, false, "someDirId", fileNameCryptor);
-
-			Assertions.assertEquals("theTrueName.txt", decryptedFile);
-		}
-
-		@Test
-		@DisplayName("restoring filename of shortened resource is successful")
-		void testRestoreFilenameShortenedSuccess() throws IOException {
-			String inflatedEncryptedName = "OrphanWithLongestName.c9r";
-			Path oldCipherPath = cipherOrphan.resolve("hashOfOrphanWithLongestName.c9r");
-			Path oldCipherPathNameFile = oldCipherPath.resolve(Constants.INFLATED_FILE_NAME);
-			Files.createDirectory(oldCipherPath);
-			Files.writeString(oldCipherPathNameFile, inflatedEncryptedName);
-			//by using Mockito.eq() in filename parameter Mockito.verfiy() not necessary
-			Mockito.when(fileNameCryptor.decryptFilename(Mockito.any(), Mockito.eq("OrphanWithLongestName"), Mockito.any())).thenReturn("theRealLongName.txt");
-
-			String decryptedFile = result.restoreFileName(oldCipherPath, true, "someDirId", fileNameCryptor);
-
-			Assertions.assertEquals("theRealLongName.txt", decryptedFile);
-		}
-
-		@Test
-		@DisplayName("restoreFilename with shortened resource throws IO exception when name.c9s cannot be read")
-		void testRestoreFilenameShortenedIOException() throws IOException {
-			Path oldCipherPath = cipherOrphan.resolve("hashOfOrphanWithLongestName.c9r");
-			Files.createDirectory(oldCipherPath);
-
-			Assertions.assertThrows(IOException.class, () -> result.restoreFileName(oldCipherPath, true, "someDirId", fileNameCryptor));
-		}
-	}
-
-
-	@Nested
 	class RetrieveDirIdTests {
 
 		private OrphanDir resultSpy;
@@ -252,7 +210,6 @@ public class OrphanDirTest {
 		@BeforeEach
 		public void init() {
 			resultSpy = Mockito.spy(result);
-			Mockito.doReturn(fileNameCryptor).when(cryptor).fileNameCryptor();
 		}
 
 		@Test
@@ -312,6 +269,49 @@ public class OrphanDirTest {
 
 
 	@Nested
+	class RestoreFilenameTests {
+
+		@Test
+		@DisplayName("restoring filename of not-shortened resource is successful")
+		void testRestoreFilenameNormalSuccess() throws IOException {
+			Path oldCipherPath = cipherOrphan.resolve("orphan.c9r");
+			Files.createFile(oldCipherPath);
+			//by using Mockito.eq() in filename parameter Mockito.verfiy() not necessary
+			Mockito.when(fileNameCryptor.decryptFilename(Mockito.any(), Mockito.eq("orphan"), Mockito.any())).thenReturn("theTrueName.txt");
+
+			String decryptedFile = result.restoreFileName(oldCipherPath, false, "someDirId", fileNameCryptor);
+
+			Assertions.assertEquals("theTrueName.txt", decryptedFile);
+		}
+
+		@Test
+		@DisplayName("restoring filename of shortened resource is successful")
+		void testRestoreFilenameShortenedSuccess() throws IOException {
+			String inflatedEncryptedName = "OrphanWithLongestName.c9r";
+			Path oldCipherPath = cipherOrphan.resolve("hashOfOrphanWithLongestName.c9r");
+			Path oldCipherPathNameFile = oldCipherPath.resolve(Constants.INFLATED_FILE_NAME);
+			Files.createDirectory(oldCipherPath);
+			Files.writeString(oldCipherPathNameFile, inflatedEncryptedName);
+			//by using Mockito.eq() in filename parameter Mockito.verfiy() not necessary
+			Mockito.when(fileNameCryptor.decryptFilename(Mockito.any(), Mockito.eq("OrphanWithLongestName"), Mockito.any())).thenReturn("theRealLongName.txt");
+
+			String decryptedFile = result.restoreFileName(oldCipherPath, true, "someDirId", fileNameCryptor);
+
+			Assertions.assertEquals("theRealLongName.txt", decryptedFile);
+		}
+
+		@Test
+		@DisplayName("restoreFilename with shortened resource throws IO exception when name.c9s cannot be read")
+		void testRestoreFilenameShortenedIOException() throws IOException {
+			Path oldCipherPath = cipherOrphan.resolve("hashOfOrphanWithLongestName.c9r");
+			Files.createDirectory(oldCipherPath);
+
+			Assertions.assertThrows(IOException.class, () -> result.restoreFileName(oldCipherPath, true, "someDirId", fileNameCryptor));
+		}
+	}
+
+
+	@Nested
 	class AdoptOrphanedTests {
 
 		@Test
@@ -352,7 +352,7 @@ public class OrphanDirTest {
 				Mockito.doReturn(new byte[]{}).when(sha1).digest(Mockito.any());
 
 				BaseEncoding base64url = Mockito.mock(BaseEncoding.class);
-				baseEncodingClass.when(() -> BaseEncoding.base64Url()).thenReturn(base64url);
+				baseEncodingClass.when(BaseEncoding::base64Url).thenReturn(base64url);
 				Mockito.doReturn("adopted_shortened").when(base64url).encode(Mockito.any());
 
 				result.adoptOrphanedResource(oldCipherPath, newClearName, true, stepParentDir, fileNameCryptor, sha1);
@@ -380,7 +380,7 @@ public class OrphanDirTest {
 				Mockito.doReturn(new byte[]{}).when(sha1).digest(Mockito.any());
 
 				BaseEncoding base64url = Mockito.mock(BaseEncoding.class);
-				baseEncodingClass.when(() -> BaseEncoding.base64Url()).thenReturn(base64url);
+				baseEncodingClass.when(BaseEncoding::base64Url).thenReturn(base64url);
 				Mockito.doReturn("adopted_shortened").when(base64url).encode(Mockito.any());
 
 				result.adoptOrphanedResource(oldCipherPath, newClearName, true, stepParentDir, fileNameCryptor, sha1);
@@ -395,8 +395,8 @@ public class OrphanDirTest {
 
 
 	@Test
-	@DisplayName("fix() prepares vault, process every resource in orphanDir and deletes orphanDir")
-	public void testFix() throws IOException {
+	@DisplayName("fix() prepares vault, process every resource in orphanDir and deletes orphanDir (dirId not present)")
+	public void testFixNoDirId() throws IOException {
 		result = new OrphanDir(dataDir.relativize(cipherOrphan));
 		var resultSpy = Mockito.spy(result);
 
@@ -410,8 +410,6 @@ public class OrphanDirTest {
 		VaultConfig config = Mockito.mock(VaultConfig.class);
 		Mockito.doReturn(170).when(config).getShorteningThreshold();
 		Masterkey masterkey = Mockito.mock(Masterkey.class);
-		Cryptor generalCryptor = Mockito.mock(Cryptor.class);
-		Mockito.doReturn(fileNameCryptor).when(generalCryptor).fileNameCryptor();
 
 		Mockito.doReturn(cipherRecovery).when(resultSpy).prepareRecoveryDir(pathToVault, fileNameCryptor);
 		Mockito.doReturn(stepParentDir).when(resultSpy).prepareStepParent(Mockito.eq(dataDir), Mockito.eq(cipherRecovery), Mockito.eq(fileNameCryptor), Mockito.any());
@@ -420,7 +418,7 @@ public class OrphanDirTest {
 			return null;
 		}).when(resultSpy).adoptOrphanedResource(Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.eq(stepParentDir), Mockito.eq(fileNameCryptor), Mockito.any());
 
-		resultSpy.fix(pathToVault, config, masterkey, generalCryptor);
+		resultSpy.fix(pathToVault, config, masterkey, cryptor);
 
 		Mockito.verify(resultSpy, Mockito.times(2)).adoptOrphanedResource(Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.eq(stepParentDir), Mockito.eq(fileNameCryptor), Mockito.any());
 		Assertions.assertTrue(Files.notExists(cipherOrphan));
@@ -428,13 +426,11 @@ public class OrphanDirTest {
 
 
 	@Test
-	@DisplayName("results with same orphan have write to same cleartext stepparent")
+	@DisplayName("results with same orphan write to same cleartext stepparent")
 	public void testFixRepeated() throws IOException {
 		VaultConfig config = Mockito.mock(VaultConfig.class);
 		Mockito.doReturn(170).when(config).getShorteningThreshold();
 		Masterkey masterkey = Mockito.mock(Masterkey.class);
-		Cryptor generalCryptor = Mockito.mock(Cryptor.class);
-		Mockito.doReturn(fileNameCryptor).when(generalCryptor).fileNameCryptor();
 
 		AtomicReference<String> clearStepparentNameRef = new AtomicReference<>("");
 
@@ -451,8 +447,8 @@ public class OrphanDirTest {
 		Mockito.doReturn(cipherRecovery).when(continuedSpy).prepareRecoveryDir(pathToVault, fileNameCryptor);
 		Mockito.doThrow(IOException.class).when(continuedSpy).prepareStepParent(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
 
-		Assertions.assertThrows(IOException.class, () -> interruptedSpy.fix(pathToVault, config, masterkey, generalCryptor));
-		Assertions.assertThrows(IOException.class, () -> continuedSpy.fix(pathToVault, config, masterkey, generalCryptor));
+		Assertions.assertThrows(IOException.class, () -> interruptedSpy.fix(pathToVault, config, masterkey, cryptor));
+		Assertions.assertThrows(IOException.class, () -> continuedSpy.fix(pathToVault, config, masterkey, cryptor));
 
 		Mockito.verify(continuedSpy).prepareStepParent(dataDir, cipherRecovery, fileNameCryptor, clearStepparentNameRef.get());
 	}
@@ -474,11 +470,9 @@ public class OrphanDirTest {
 		VaultConfig config = Mockito.mock(VaultConfig.class);
 		Mockito.doReturn(170).when(config).getShorteningThreshold();
 		Masterkey masterkey = Mockito.mock(Masterkey.class);
-		Cryptor generalCryptor = Mockito.mock(Cryptor.class);
-		Mockito.doReturn(fileNameCryptor).when(generalCryptor).fileNameCryptor();
 		Mockito.doReturn(cipherRecovery).when(resultSpy).prepareRecoveryDir(pathToVault, fileNameCryptor);
 
-		resultSpy.fix(pathToVault, config, masterkey, generalCryptor);
+		resultSpy.fix(pathToVault, config, masterkey, cryptor);
 
 		Mockito.verify(resultSpy, Mockito.never()).prepareStepParent(Mockito.eq(dataDir), Mockito.eq(cipherRecovery), Mockito.eq(fileNameCryptor), Mockito.any());
 		Mockito.verify(resultSpy, Mockito.never()).adoptOrphanedResource(Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.any(), Mockito.eq(fileNameCryptor), Mockito.any());

--- a/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
@@ -8,7 +8,7 @@ import org.cryptomator.cryptolib.api.AuthenticationFailedException;
 import org.cryptomator.cryptolib.api.Cryptor;
 import org.cryptomator.cryptolib.api.FileNameCryptor;
 import org.cryptomator.cryptolib.api.Masterkey;
-import org.cryptomator.cryptolib.common.EncryptingReadableByteChannel;
+import org.cryptomator.cryptolib.common.DecryptingReadableByteChannel;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
@@ -219,13 +220,15 @@ public class OrphanDirTest {
 		public void testRetrieveDirIdSuccess() throws IOException {
 			var dirIdFile = cipherOrphan.resolve(Constants.DIR_ID_FILE);
 			var dirId = "random-uuid-with-at-most-36chars";
+
 			Files.writeString(dirIdFile, dirId, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
-			EncryptingReadableByteChannel dirIdReadChannel = Mockito.mock(EncryptingReadableByteChannel.class);
+			DecryptingReadableByteChannel dirIdReadChannel = Mockito.mock(DecryptingReadableByteChannel.class);
 
 			Mockito.doReturn(dirIdReadChannel).when(resultSpy).wrapDecryptionAround(Mockito.any(), Mockito.eq(cryptor));
 			Mockito.doAnswer(invocationOnMock -> {
+				ByteBuffer buf = invocationOnMock.getArgument(0);
 				try (ReadableByteChannel channel = Files.newByteChannel(dirIdFile, StandardOpenOption.READ)) {
-					return channel.read(invocationOnMock.getArgument(0));
+					return channel.read(buf);
 				}
 			}).when(dirIdReadChannel).read(Mockito.any());
 
@@ -252,7 +255,7 @@ public class OrphanDirTest {
 			var dirIdFile = cipherOrphan.resolve(Constants.DIR_ID_FILE);
 			var dirId = "anOverlyComplexAndCompletelyRandomExampleOfHowAnDirectoryIdIsTooLong";
 			Files.writeString(dirIdFile, dirId, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
-			EncryptingReadableByteChannel dirIdReadChannel = Mockito.mock(EncryptingReadableByteChannel.class);
+			DecryptingReadableByteChannel dirIdReadChannel = Mockito.mock(DecryptingReadableByteChannel.class);
 
 			Mockito.doReturn(dirIdReadChannel).when(resultSpy).wrapDecryptionAround(Mockito.any(), Mockito.eq(cryptor));
 			Mockito.doAnswer(invocationOnMock -> {


### PR DESCRIPTION
Closes #126.

This PR allows to restore also filenames of an orphaned directory, if the dirId file is present.

It is implemented in a failsafe way: If the dirId file does not exists, cannot be read or does not match, the orphan cipher dir is recovered without it.