### PR TITLE
Handle root path as filesystem API parameter gracefully

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemImpl.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemImpl.java
@@ -430,6 +430,11 @@ class CryptoFileSystemImpl extends CryptoFileSystem {
 		if (cleartextSource.equals(cleartextTarget)) {
 			return;
 		}
+
+		if (rootPath.equals(cleartextTarget) && ArrayUtils.contains(options, StandardCopyOption.REPLACE_EXISTING)) {
+			throw new FileSystemException("The filesystem root cannot be replaced.");
+		}
+
 		CiphertextFileType ciphertextFileType = cryptoPathMapper.getCiphertextFileType(cleartextSource);
 		if (!ArrayUtils.contains(options, StandardCopyOption.REPLACE_EXISTING)) {
 			cryptoPathMapper.assertNonExisting(cleartextTarget);

--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemImpl.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemImpl.java
@@ -531,7 +531,8 @@ class CryptoFileSystemImpl extends CryptoFileSystem {
 		assertCleartextNameLengthAllowed(cleartextTarget);
 
 		if (rootPath.equals(cleartextSource)) {
-			throw new FileSystemException("Filesystem root cannot be deleted.");
+			throw new FileSystemException("Filesystem root cannot be moved.");
+
 		}
 
 		if (rootPath.equals(cleartextTarget)) {

--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemImpl.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemImpl.java
@@ -35,6 +35,7 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.DirectoryStream.Filter;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileStore;
+import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
@@ -391,6 +392,9 @@ class CryptoFileSystemImpl extends CryptoFileSystem {
 
 	void delete(CryptoPath cleartextPath) throws IOException {
 		readonlyFlag.assertWritable();
+		if(rootPath.equals(cleartextPath)) {
+			throw new FileSystemException("The filesystem root cannot be deleted.");
+		}
 		CiphertextFileType ciphertextFileType = cryptoPathMapper.getCiphertextFileType(cleartextPath);
 		CiphertextFilePath ciphertextPath = cryptoPathMapper.getCiphertextFilePath(cleartextPath);
 		switch (ciphertextFileType) {

--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemImpl.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemImpl.java
@@ -524,6 +524,15 @@ class CryptoFileSystemImpl extends CryptoFileSystem {
 	void move(CryptoPath cleartextSource, CryptoPath cleartextTarget, CopyOption... options) throws IOException {
 		readonlyFlag.assertWritable();
 		assertCleartextNameLengthAllowed(cleartextTarget);
+
+		if(rootPath.equals(cleartextSource)) {
+			throw new FileSystemException("Filesystem root cannot be deleted.");
+		}
+
+		if(rootPath.equals(cleartextTarget)) {
+			throw new FileAlreadyExistsException(rootPath.toString());
+		}
+
 		if (cleartextSource.equals(cleartextTarget)) {
 			return;
 		}

--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemImpl.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemImpl.java
@@ -59,6 +59,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -628,7 +629,7 @@ class CryptoFileSystemImpl extends CryptoFileSystem {
 	}
 
 	void assertCleartextNameLengthAllowed(CryptoPath cleartextPath) throws FileNameTooLongException {
-		String filename = cleartextPath.getFileName().toString();
+		String filename = Optional.ofNullable(cleartextPath.getFileName()).map(CryptoPath::toString).orElse(""); //fs root has no explicit name
 		if (filename.length() > fileSystemProperties.maxCleartextNameLength()) {
 			throw new FileNameTooLongException(cleartextPath.toString(), fileSystemProperties.maxCleartextNameLength());
 		}

--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemImpl.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemImpl.java
@@ -290,7 +290,7 @@ class CryptoFileSystemImpl extends CryptoFileSystem {
 	void createDirectory(CryptoPath cleartextDir, FileAttribute<?>... attrs) throws IOException {
 		readonlyFlag.assertWritable();
 		assertCleartextNameLengthAllowed(cleartextDir);
-		if(rootPath.equals(cleartextDir)) {
+		if (rootPath.equals(cleartextDir)) {
 			throw new FileAlreadyExistsException(rootPath.toString());
 		}
 
@@ -388,7 +388,7 @@ class CryptoFileSystemImpl extends CryptoFileSystem {
 				stats.incrementAccessesRead();
 			}
 			return ch;
-		} catch (Exception e){
+		} catch (Exception e) {
 			ch.close();
 			throw e;
 		}
@@ -396,7 +396,7 @@ class CryptoFileSystemImpl extends CryptoFileSystem {
 
 	void delete(CryptoPath cleartextPath) throws IOException {
 		readonlyFlag.assertWritable();
-		if(rootPath.equals(cleartextPath)) {
+		if (rootPath.equals(cleartextPath)) {
 			throw new FileSystemException("The filesystem root cannot be deleted.");
 		}
 		CiphertextFileType ciphertextFileType = cryptoPathMapper.getCiphertextFileType(cleartextPath);
@@ -530,11 +530,11 @@ class CryptoFileSystemImpl extends CryptoFileSystem {
 		readonlyFlag.assertWritable();
 		assertCleartextNameLengthAllowed(cleartextTarget);
 
-		if(rootPath.equals(cleartextSource)) {
+		if (rootPath.equals(cleartextSource)) {
 			throw new FileSystemException("Filesystem root cannot be deleted.");
 		}
 
-		if(rootPath.equals(cleartextTarget)) {
+		if (rootPath.equals(cleartextTarget)) {
 			throw new FileAlreadyExistsException(rootPath.toString());
 		}
 

--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemImpl.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemImpl.java
@@ -290,6 +290,10 @@ class CryptoFileSystemImpl extends CryptoFileSystem {
 	void createDirectory(CryptoPath cleartextDir, FileAttribute<?>... attrs) throws IOException {
 		readonlyFlag.assertWritable();
 		assertCleartextNameLengthAllowed(cleartextDir);
+		if(rootPath.equals(cleartextDir)) {
+			throw new FileAlreadyExistsException(rootPath.toString());
+		}
+
 		CryptoPath cleartextParentDir = cleartextDir.getParent();
 		if (cleartextParentDir == null) {
 			return;

--- a/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemImplTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemImplTest.java
@@ -1490,6 +1490,7 @@ public class CryptoFileSystemImplTest {
 			when(p.getFileName()).thenReturn(p);
 			when(p.toString()).thenReturn("takatuka");
 		}
+
 		@Test
 		public void testFittingPath() {
 			when(fileSystemProperties.maxCleartextNameLength()).thenReturn(20);

--- a/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemImplTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemImplTest.java
@@ -37,6 +37,7 @@ import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystem;
+import java.nio.file.FileSystemException;
 import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
@@ -479,6 +480,11 @@ public class CryptoFileSystemImplTest {
 			when(physicalFsProv.readAttributes(ciphertextRawPath, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS)).thenReturn(ciphertextPathAttr);
 			when(physicalFsProv.readAttributes(ciphertextDirFilePath, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS)).thenReturn(ciphertextDirFilePathAttr);
 
+		}
+
+		@Test
+		public void testDeleteRootFails() {
+			Assertions.assertThrows(FileSystemException.class, () -> inTest.delete(root));
 		}
 
 		@Test

--- a/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemImplTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemImplTest.java
@@ -1008,6 +1008,11 @@ public class CryptoFileSystemImplTest {
 		}
 
 		@Test
+		public void createFilesystemRootFails() {
+			Assertions.assertThrows(FileAlreadyExistsException.class, () -> inTest.createDirectory(root));
+		}
+
+		@Test
 		public void createDirectoryIfPathHasNoParentDoesNothing() throws IOException {
 			when(path.getParent()).thenReturn(null);
 

--- a/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemImplTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemImplTest.java
@@ -1454,4 +1454,34 @@ public class CryptoFileSystemImplTest {
 
 	}
 
+	@Nested
+	public class AssertFileNameLength {
+
+		CryptoPath p = Mockito.mock(CryptoPath.class);
+
+		@BeforeEach
+		public void init() {
+			when(p.getFileName()).thenReturn(p);
+			when(p.toString()).thenReturn("takatuka");
+		}
+		@Test
+		public void testFittingPath() {
+			when(fileSystemProperties.maxCleartextNameLength()).thenReturn(20);
+			Assertions.assertDoesNotThrow(() -> inTest.assertCleartextNameLengthAllowed(p));
+		}
+
+		@Test
+		public void testTooLongPath() {
+			when(fileSystemProperties.maxCleartextNameLength()).thenReturn(4);
+			Assertions.assertThrows(FileNameTooLongException.class, () -> inTest.assertCleartextNameLengthAllowed(p));
+		}
+
+		@Test
+		public void testRootPath() {
+			when(fileSystemProperties.maxCleartextNameLength()).thenReturn(0);
+			when(p.getFileName()).thenReturn(null);
+			Assertions.assertDoesNotThrow(() -> inTest.assertCleartextNameLengthAllowed(p));
+		}
+	}
+
 }

--- a/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemImplTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemImplTest.java
@@ -782,6 +782,11 @@ public class CryptoFileSystemImplTest {
 			}
 
 			@Test
+			public void copyToRootWithReplacingFails() {
+				Assertions.assertThrows(FileSystemException.class, () -> inTest.copy(cleartextSource, root, StandardCopyOption.REPLACE_EXISTING));
+			}
+
+			@Test
 			public void copyNonExistingFile() throws IOException {
 				when(cryptoPathMapper.getCiphertextFileType(cleartextSource)).thenThrow(NoSuchFileException.class);
 

--- a/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemImplTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemImplTest.java
@@ -614,6 +614,16 @@ public class CryptoFileSystemImplTest {
 			}
 
 			@Test
+			public void moveFilesystemRootFails() {
+				Assertions.assertThrows(FileSystemException.class, () -> inTest.move(root, cleartextDestination));
+			}
+
+			@Test
+			public void moveToFilesystemRootFails() {
+				Assertions.assertThrows(FileSystemException.class, () -> inTest.move(cleartextSource, root));
+			}
+
+			@Test
 			public void moveNonExistingFile() throws IOException {
 				when(cryptoPathMapper.getCiphertextFileType(cleartextSource)).thenThrow(NoSuchFileException.class);
 


### PR DESCRIPTION
Closes #132.

Destructive methods (`createDirectory`, `delete`, `copy` and `move`) are adjusted to throw an Filesystemexception when the root path is a parameter.