### PR TITLE
Add "missing dirid backup file" result to directory check

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/DirIdCheck.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/DirIdCheck.java
@@ -61,7 +61,11 @@ public class DirIdCheck implements HealthCheck {
 			boolean foundDir = dirVisitor.secondLevelDirs.remove(expectedDir);
 			if (foundDir) {
 				iter.remove();
-				resultCollector.accept(new HealthyDir(dirId, dirIdFile, expectedDir));
+				if(Files.exists(expectedDir.resolve(Constants.DIR_ID_FILE))) {
+					resultCollector.accept(new HealthyDir(dirId, dirIdFile, expectedDir));
+				} else {
+					resultCollector.accept(new MissingDirIdFile(dirId, expectedDir));
+				}
 			}
 		}
 

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/DirIdCheck.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/DirIdCheck.java
@@ -64,7 +64,7 @@ public class DirIdCheck implements HealthCheck {
 				if(Files.exists(expectedDir.resolve(Constants.DIR_ID_FILE))) {
 					resultCollector.accept(new HealthyDir(dirId, dirIdFile, expectedDir));
 				} else {
-					resultCollector.accept(new MissingDirIdFile(dirId, expectedDir));
+					resultCollector.accept(new MissingDirIdBackup(dirId, expectedDir));
 				}
 			}
 		}

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/MissingDirIdBackup.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/MissingDirIdBackup.java
@@ -13,12 +13,12 @@ import java.nio.file.Path;
 /**
  * TODO: adjust DirIdCheck
  */
-public class MissingDirIdFile implements DiagnosticResult {
+public class MissingDirIdBackup implements DiagnosticResult {
 
 	private final Path cipherDir;
 	private final String dirId;
 
-	MissingDirIdFile(String dirId, Path cipherDir)  {
+	MissingDirIdBackup(String dirId, Path cipherDir)  {
 		this.cipherDir = cipherDir;
 		this.dirId = dirId;
 	}

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/MissingDirIdBackup.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/MissingDirIdBackup.java
@@ -11,26 +11,23 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 /**
- * TODO: adjust DirIdCheck
+ * The dir id backup file is missing.
  */
-public class MissingDirIdBackup implements DiagnosticResult {
-
-	private final Path cipherDir;
-	private final String dirId;
-
-	MissingDirIdBackup(String dirId, Path cipherDir)  {
-		this.cipherDir = cipherDir;
-		this.dirId = dirId;
-	}
+public record MissingDirIdBackup(String dirId, Path cipherDir) implements DiagnosticResult {
 
 	@Override
 	public Severity getSeverity() {
-		return Severity.WARN; //TODO: decide severity
+		return Severity.WARN;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("Directory ID backup for directory %s is missing.", cipherDir);
 	}
 
 	@Override
 	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
 		DirectoryIdBackup dirIdBackup = new DirectoryIdBackup(cryptor);
-		dirIdBackup.execute(new CryptoPathMapper.CiphertextDirectory(dirId,cipherDir));
+		dirIdBackup.execute(new CryptoPathMapper.CiphertextDirectory(dirId, cipherDir));
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/MissingDirIdFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/MissingDirIdFile.java
@@ -1,0 +1,36 @@
+package org.cryptomator.cryptofs.health.dirid;
+
+import org.cryptomator.cryptofs.CryptoPathMapper;
+import org.cryptomator.cryptofs.DirectoryIdBackup;
+import org.cryptomator.cryptofs.VaultConfig;
+import org.cryptomator.cryptofs.health.api.DiagnosticResult;
+import org.cryptomator.cryptolib.api.Cryptor;
+import org.cryptomator.cryptolib.api.Masterkey;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * TODO: adjust DirIdCheck
+ */
+public class MissingDirIdFile implements DiagnosticResult {
+
+	private final Path cipherDir;
+	private final String dirId;
+
+	MissingDirIdFile(String dirId, Path cipherDir)  {
+		this.cipherDir = cipherDir;
+		this.dirId = dirId;
+	}
+
+	@Override
+	public Severity getSeverity() {
+		return Severity.WARN; //TODO: decide severity
+	}
+
+	@Override
+	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
+		DirectoryIdBackup dirIdBackup = new DirectoryIdBackup(cryptor);
+		dirIdBackup.execute(new CryptoPathMapper.CiphertextDirectory(dirId,cipherDir));
+	}
+}


### PR DESCRIPTION
Closes #128.

The result has severity `WARN`. 
The fix is to create the backup file.
The result is created, when a healthy Dir without the backup file is found.