### PR TITLE
fix `CryptoBasicFileAttributes` #GH-141

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/attr/CryptoBasicFileAttributes.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/CryptoBasicFileAttributes.java
@@ -34,10 +34,7 @@ sealed class CryptoBasicFileAttributes implements BasicFileAttributes
 
 	public CryptoBasicFileAttributes(BasicFileAttributes delegate, CiphertextFileType ciphertextFileType, Path ciphertextPath, Cryptor cryptor, Optional<OpenCryptoFile> openCryptoFile) {
 		this.ciphertextFileType = ciphertextFileType;
-		this.size = switch (ciphertextFileType) {
-			case SYMLINK, DIRECTORY -> delegate.size();
-			case FILE -> getPlaintextFileSize(ciphertextPath, delegate.size(), openCryptoFile, cryptor);
-		};
+		this.size = getPlaintextFileSize(ciphertextPath, delegate.size(), openCryptoFile, cryptor);
 		this.lastModifiedTime =  openCryptoFile.map(OpenCryptoFile::getLastModifiedTime).orElseGet(delegate::lastModifiedTime);
 		this.lastAccessTime = openCryptoFile.map(openFile -> FileTime.from(Instant.now())).orElseGet(delegate::lastAccessTime);
 		this.creationTime = delegate.creationTime();

--- a/src/main/java/org/cryptomator/cryptofs/attr/CryptoBasicFileAttributes.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/CryptoBasicFileAttributes.java
@@ -34,7 +34,10 @@ sealed class CryptoBasicFileAttributes implements BasicFileAttributes
 
 	public CryptoBasicFileAttributes(BasicFileAttributes delegate, CiphertextFileType ciphertextFileType, Path ciphertextPath, Cryptor cryptor, Optional<OpenCryptoFile> openCryptoFile) {
 		this.ciphertextFileType = ciphertextFileType;
-		this.size = ciphertextFileType != DIRECTORY ? getPlaintextFileSize(ciphertextPath, delegate.size(), openCryptoFile, cryptor) : delegate.size();
+		this.size = switch (ciphertextFileType) {
+			case DIRECTORY -> delegate.size();
+			case SYMLINK, FILE -> getPlaintextFileSize(ciphertextPath, delegate.size(), openCryptoFile, cryptor);
+		};
 		this.lastModifiedTime =  openCryptoFile.map(OpenCryptoFile::getLastModifiedTime).orElseGet(delegate::lastModifiedTime);
 		this.lastAccessTime = openCryptoFile.map(openFile -> FileTime.from(Instant.now())).orElseGet(delegate::lastAccessTime);
 		this.creationTime = delegate.creationTime();

--- a/src/main/java/org/cryptomator/cryptofs/attr/CryptoBasicFileAttributes.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/CryptoBasicFileAttributes.java
@@ -34,7 +34,7 @@ sealed class CryptoBasicFileAttributes implements BasicFileAttributes
 
 	public CryptoBasicFileAttributes(BasicFileAttributes delegate, CiphertextFileType ciphertextFileType, Path ciphertextPath, Cryptor cryptor, Optional<OpenCryptoFile> openCryptoFile) {
 		this.ciphertextFileType = ciphertextFileType;
-		this.size = getPlaintextFileSize(ciphertextPath, delegate.size(), openCryptoFile, cryptor);
+		this.size = ciphertextFileType != DIRECTORY ? getPlaintextFileSize(ciphertextPath, delegate.size(), openCryptoFile, cryptor) : delegate.size();
 		this.lastModifiedTime =  openCryptoFile.map(OpenCryptoFile::getLastModifiedTime).orElseGet(delegate::lastModifiedTime);
 		this.lastAccessTime = openCryptoFile.map(openFile -> FileTime.from(Instant.now())).orElseGet(delegate::lastAccessTime);
 		this.creationTime = delegate.creationTime();


### PR DESCRIPTION
the old implementation returns wrong file size for symbolic links, e.g. file `symlink` after `ln -s . symlink` should be 1