### PR TITLE
Health API: Decouple result fix from severity

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/health/api/DiagnosticResult.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/api/DiagnosticResult.java
@@ -63,7 +63,9 @@ public interface DiagnosticResult {
 	 */
 	@Deprecated
 	default void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
-		throw new UnsupportedOperationException("Fix for result" + this.getClass() + " not implemented");
+		getFix(pathToVault, config, masterkey, cryptor) //
+				.orElseThrow(() -> new UnsupportedOperationException("Fix for result" + this.getClass() + " not implemented")) //
+				.apply();
 	}
 
 	default Optional<Fix> getFix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) {
@@ -81,6 +83,7 @@ public interface DiagnosticResult {
 
 	@FunctionalInterface
 	interface Fix {
+
 		void apply() throws IOException;
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/api/DiagnosticResult.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/api/DiagnosticResult.java
@@ -7,6 +7,7 @@ import org.cryptomator.cryptolib.api.Masterkey;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Optional;
 
 public interface DiagnosticResult {
 
@@ -17,17 +18,24 @@ public interface DiagnosticResult {
 		GOOD,
 
 		/**
-		 * Unexpected, but nothing to worry about. May be worth logging
+		 * No impact on vault structure, no data lass, but noteworthy.
+		 * <p>
+		 * If a fix is present, applying it is recommended.
 		 */
 		INFO,
 
 		/**
-		 * Compromises vault structure, can and should be fixed.
+		 * Compromises vault structure, but no apparent data loss.
+		 * <p>
+		 * If a fix is present, applying it is highly advised to prevent data loss.
 		 */
 		WARN,
 
 		/**
-		 * Irreversible damage, no automated way of fixing this issue.
+		 * Compromises vault structure, data loss happened.
+		 * <p>
+		 * Restore from backups is advised.
+		 * If not possible and a fix present, applying it is recommended to restore vault structure.
 		 */
 		CRITICAL;
 	}
@@ -40,8 +48,26 @@ public interface DiagnosticResult {
 	@Override
 	String toString();
 
+	/**
+	 * A fix for the result.
+	 * <p>
+	 * "Fix" does not imply to restore lost data. It only implies, that the issue leading to this result is resolved.
+	 *
+	 * @param pathToVault path to the root directory of the vault
+	 * @param config the vault config
+	 * @param masterkey the masterkey of the vault
+	 * @param cryptor
+	 * @throws IOException
+	 * @throws UnsupportedOperationException if no fix is implemented for this result
+	 * @deprecated Use {@link #getFix(Path, VaultConfig, Masterkey, Cryptor)} instead
+	 */
+	@Deprecated
 	default void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
 		throw new UnsupportedOperationException("Fix for result" + this.getClass() + " not implemented");
+	}
+
+	default Optional<Fix> getFix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) {
+		return Optional.empty();
 	}
 
 	/**
@@ -51,5 +77,10 @@ public interface DiagnosticResult {
 	 */
 	default Map<String, String> details() {
 		return Map.of();
+	}
+
+	@FunctionalInterface
+	interface Fix {
+		void apply() throws IOException;
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/LooseDirFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/LooseDirFile.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.cryptomator.cryptofs.health.api.CommonDetailKeys.DIR_FILE;
 
@@ -36,6 +37,11 @@ public class LooseDirFile implements DiagnosticResult {
 	@Override
 	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
 		Files.deleteIfExists(dirFile);
+	}
+
+	@Override
+	public Optional<Fix> getFix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) {
+		return Optional.of(() -> fix(pathToVault, config, masterkey, cryptor));
 	}
 
 	@Override

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/LooseDirFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/LooseDirFile.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 import static org.cryptomator.cryptofs.health.api.CommonDetailKeys.DIR_FILE;
 
 /**
- *	Diagnostic result of a dir file without the expected parent directories.
+ * Diagnostic result of a dir file without the expected parent directories.
  */
 public class LooseDirFile implements DiagnosticResult {
 
@@ -35,13 +35,13 @@ public class LooseDirFile implements DiagnosticResult {
 	}
 
 	@Override
-	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
-		Files.deleteIfExists(dirFile);
+	public Optional<Fix> getFix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) {
+		return Optional.of(() -> fix(pathToVault));
 	}
 
-	@Override
-	public Optional<Fix> getFix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) {
-		return Optional.of(() -> fix(pathToVault, config, masterkey, cryptor));
+	//visible for testing
+	void fix(Path pathToVault) throws IOException {
+		Files.deleteIfExists(pathToVault.resolve(dirFile));
 	}
 
 	@Override

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/MissingContentDir.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/MissingContentDir.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.cryptomator.cryptofs.health.api.CommonDetailKeys.DIR_ID;
 import static org.cryptomator.cryptofs.health.api.CommonDetailKeys.DIR_FILE;
@@ -51,5 +52,10 @@ public class MissingContentDir implements DiagnosticResult {
 		Path dirPath = pathToVault.resolve(Constants.DATA_DIR_NAME).resolve(dirIdHash.substring(0, 2)).resolve(dirIdHash.substring(2, 30));
 		Files.createDirectories(dirPath);
 		DirectoryIdBackup.backupManually(cryptor, new CryptoPathMapper.CiphertextDirectory(dirId, dirPath));
+	}
+
+	@Override
+	public Optional<Fix> getFix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) {
+		return Optional.of(() -> fix(pathToVault, config, masterkey, cryptor));
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/MissingContentDir.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/MissingContentDir.java
@@ -14,8 +14,8 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.cryptomator.cryptofs.health.api.CommonDetailKeys.DIR_ID;
 import static org.cryptomator.cryptofs.health.api.CommonDetailKeys.DIR_FILE;
+import static org.cryptomator.cryptofs.health.api.CommonDetailKeys.DIR_ID;
 
 /**
  * Valid dir.c9r file, nonexisting content dir
@@ -46,8 +46,8 @@ public class MissingContentDir implements DiagnosticResult {
 				DIR_FILE, dirFile.toString());
 	}
 
-	@Override
-	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
+	//visible for testing
+	void fix(Path pathToVault, Cryptor cryptor) throws IOException {
 		var dirIdHash = cryptor.fileNameCryptor().hashDirectoryId(dirId);
 		Path dirPath = pathToVault.resolve(Constants.DATA_DIR_NAME).resolve(dirIdHash.substring(0, 2)).resolve(dirIdHash.substring(2, 30));
 		Files.createDirectories(dirPath);
@@ -56,6 +56,6 @@ public class MissingContentDir implements DiagnosticResult {
 
 	@Override
 	public Optional<Fix> getFix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) {
-		return Optional.of(() -> fix(pathToVault, config, masterkey, cryptor));
+		return Optional.of(() -> fix(pathToVault, cryptor));
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/MissingDirIdBackup.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/MissingDirIdBackup.java
@@ -10,6 +10,7 @@ import org.cryptomator.cryptolib.api.Masterkey;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Optional;
 
 /**
  * The dir id backup file {@value org.cryptomator.cryptofs.common.Constants#DIR_BACKUP_FILE_NAME} is missing.
@@ -18,7 +19,7 @@ public record MissingDirIdBackup(String dirId, Path contentDir) implements Diagn
 
 	@Override
 	public Severity getSeverity() {
-		return Severity.WARN;
+		return Severity.INFO;
 	}
 
 	@Override
@@ -30,5 +31,10 @@ public record MissingDirIdBackup(String dirId, Path contentDir) implements Diagn
 	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
 		Path absCipherDir = pathToVault.resolve(Constants.DATA_DIR_NAME).resolve(contentDir);
 		DirectoryIdBackup.backupManually(cryptor, new CryptoPathMapper.CiphertextDirectory(dirId, absCipherDir));
+	}
+
+	@Override
+	public Optional<Fix> getFix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) {
+		return Optional.of(() -> fix(pathToVault, config, masterkey, cryptor));
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/MissingDirIdBackup.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/MissingDirIdBackup.java
@@ -27,14 +27,14 @@ public record MissingDirIdBackup(String dirId, Path contentDir) implements Diagn
 		return String.format("Directory ID backup for directory %s is missing.", contentDir);
 	}
 
-	@Override
-	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
+	//visible for testing
+	void fix(Path pathToVault, Cryptor cryptor) throws IOException {
 		Path absCipherDir = pathToVault.resolve(Constants.DATA_DIR_NAME).resolve(contentDir);
 		DirectoryIdBackup.backupManually(cryptor, new CryptoPathMapper.CiphertextDirectory(dirId, absCipherDir));
 	}
 
 	@Override
 	public Optional<Fix> getFix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) {
-		return Optional.of(() -> fix(pathToVault, config, masterkey, cryptor));
+		return Optional.of(() -> fix(pathToVault, cryptor));
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanContentDir.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanContentDir.java
@@ -69,11 +69,10 @@ public class OrphanContentDir implements DiagnosticResult {
 
 	@Override
 	public Optional<Fix> getFix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) {
-		return Optional.of(() -> fix(pathToVault, config, masterkey, cryptor));
+		return Optional.of(() -> fix(pathToVault, config, cryptor));
 	}
 
-	@Override
-	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
+	private void fix(Path pathToVault, VaultConfig config, Cryptor cryptor) throws IOException {
 		var sha1 = getSha1MessageDigest();
 		String runId = Integer.toString((short) UUID.randomUUID().getMostSignificantBits(), 32);
 		Path dataDir = pathToVault.resolve(Constants.DATA_DIR_NAME);
@@ -145,7 +144,7 @@ public class OrphanContentDir implements DiagnosticResult {
 
 	// visible for testing
 	CryptoPathMapper.CiphertextDirectory prepareStepParent(Path dataDir, Path cipherRecoveryDir, Cryptor cryptor, String clearStepParentDirName) throws IOException {
-		//create "step-parent" directory to move orphaned files to
+		//create "stepparent" directory to move orphaned files to
 		String cipherStepParentDirName = encrypt(cryptor.fileNameCryptor(), clearStepParentDirName, Constants.RECOVERY_DIR_ID);
 		Path cipherStepParentDirFile = cipherRecoveryDir.resolve(cipherStepParentDirName + "/" + Constants.DIR_FILE_NAME);
 		final String stepParentUUID;

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanContentDir.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanContentDir.java
@@ -68,6 +68,11 @@ public class OrphanContentDir implements DiagnosticResult {
 	}
 
 	@Override
+	public Optional<Fix> getFix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) {
+		return Optional.of(() -> fix(pathToVault, config, masterkey, cryptor));
+	}
+
+	@Override
 	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
 		var sha1 = getSha1MessageDigest();
 		String runId = Integer.toString((short) UUID.randomUUID().getMostSignificantBits(), 32);

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/LongShortNamesMismatch.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/LongShortNamesMismatch.java
@@ -8,6 +8,7 @@ import org.cryptomator.cryptolib.api.Masterkey;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 
 /**
  * A c9s directory where the name of the directory is not a Base64URL encoded SHA1-hash of the contents in {@value org.cryptomator.cryptofs.common.Constants#INFLATED_FILE_NAME}
@@ -36,6 +37,11 @@ public class LongShortNamesMismatch implements DiagnosticResult {
 	@Override
 	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
 		Files.move(c9sDir, c9sDir.resolveSibling(expectedShortName));
+	}
+
+	@Override
+	public Optional<Fix> getFix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) {
+		return Optional.of(() -> fix(pathToVault, config, masterkey, cryptor));
 	}
 
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/LongShortNamesMismatch.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/LongShortNamesMismatch.java
@@ -34,14 +34,14 @@ public class LongShortNamesMismatch implements DiagnosticResult {
 	}
 
 	// fix by renaming the parent to the content of name.c9s
-	@Override
-	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
-		Files.move(c9sDir, c9sDir.resolveSibling(expectedShortName));
+	void fix(Path pathToVault) throws IOException {
+		var absPathC9sDir = pathToVault.resolve(c9sDir);
+		Files.move(absPathC9sDir, absPathC9sDir.resolveSibling(expectedShortName));
 	}
 
 	@Override
 	public Optional<Fix> getFix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) {
-		return Optional.of(() -> fix(pathToVault, config, masterkey, cryptor));
+		return Optional.of(() -> fix(pathToVault));
 	}
 
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/TrailingBytesInNameFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/TrailingBytesInNameFile.java
@@ -34,8 +34,8 @@ public class TrailingBytesInNameFile implements DiagnosticResult {
 		return Severity.WARN;
 	}
 
-	@Override
-	public void fix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) throws IOException {
+	//visible for testing
+	void fix(Path pathToVault) throws IOException {
 		var startIndexTrailingBytes = longName.indexOf(CRYPTOMATOR_FILE_SUFFIX) + CRYPTOMATOR_FILE_SUFFIX.length();
 		Files.writeString(pathToVault.resolve(nameFile), //
 				longName.substring(0, startIndexTrailingBytes), //
@@ -45,7 +45,7 @@ public class TrailingBytesInNameFile implements DiagnosticResult {
 
 	@Override
 	public Optional<Fix> getFix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) {
-		return Optional.of(() -> fix(pathToVault, config, masterkey, cryptor));
+		return Optional.of(() -> fix(pathToVault));
 	}
 
 	@Override

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/TrailingBytesInNameFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/TrailingBytesInNameFile.java
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.cryptomator.cryptofs.common.Constants.CRYPTOMATOR_FILE_SUFFIX;
 
@@ -40,6 +41,11 @@ public class TrailingBytesInNameFile implements DiagnosticResult {
 				longName.substring(0, startIndexTrailingBytes), //
 				StandardCharsets.UTF_8, //
 				StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+	}
+
+	@Override
+	public Optional<Fix> getFix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) {
+		return Optional.of(() -> fix(pathToVault, config, masterkey, cryptor));
 	}
 
 	@Override

--- a/src/test/java/org/cryptomator/cryptofs/health/dirid/LooseDirFileTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/dirid/LooseDirFileTest.java
@@ -1,0 +1,39 @@
+package org.cryptomator.cryptofs.health.dirid;
+
+import org.cryptomator.cryptofs.VaultConfig;
+import org.cryptomator.cryptolib.api.Cryptor;
+import org.cryptomator.cryptolib.api.Masterkey;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class LooseDirFileTest {
+
+	LooseDirFile result;
+
+	@DisplayName("LooseDirFile has a fix")
+	@Test
+	public void testGetFix() {
+		Path somePath = Path.of("foo/bar");
+		result = new LooseDirFile(somePath);
+		Assertions.assertTrue(result.getFix(Mockito.mock(Path.class), Mockito.mock(VaultConfig.class), Mockito.mock(Masterkey.class), Mockito.mock(Cryptor.class)).isPresent());
+	}
+
+	@DisplayName("LooseDirFile fix deletes loose file")
+	@Test
+	public void testFix(@TempDir Path tmpDir) throws IOException {
+		Path dirFile = tmpDir.resolve("loose.c9r");
+
+		Files.createFile(dirFile);
+		result = new LooseDirFile(dirFile.getFileName());
+		result.fix(tmpDir);
+		Assertions.assertTrue(Files.notExists(dirFile));
+	}
+
+}

--- a/src/test/java/org/cryptomator/cryptofs/health/dirid/LooseDirFileTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/dirid/LooseDirFileTest.java
@@ -20,8 +20,7 @@ public class LooseDirFileTest {
 	@DisplayName("LooseDirFile has a fix")
 	@Test
 	public void testGetFix() {
-		Path somePath = Path.of("foo/bar");
-		result = new LooseDirFile(somePath);
+		result = new LooseDirFile(Mockito.mock(Path.class));
 		Assertions.assertTrue(result.getFix(Mockito.mock(Path.class), Mockito.mock(VaultConfig.class), Mockito.mock(Masterkey.class), Mockito.mock(Cryptor.class)).isPresent());
 	}
 

--- a/src/test/java/org/cryptomator/cryptofs/health/dirid/MissingContentDirTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/dirid/MissingContentDirTest.java
@@ -43,6 +43,12 @@ public class MissingContentDirTest {
 		Mockito.doReturn(fileNameCryptor).when(cryptor).fileNameCryptor();
 	}
 
+	@DisplayName("Missing ContentDir result has a fix")
+	@Test
+	public void testGetFix() {
+		Assertions.assertTrue(result.getFix(Mockito.mock(Path.class), Mockito.mock(VaultConfig.class), Mockito.mock(Masterkey.class), Mockito.mock(Cryptor.class)).isPresent());
+	}
+
 	@DisplayName("After fix the content dir including dirId file exists ")
 	@Test
 	public void testFix() throws IOException {
@@ -51,7 +57,7 @@ public class MissingContentDirTest {
 		try (var dirIdBackupMock = Mockito.mockStatic(DirectoryIdBackup.class)) {
 			dirIdBackupMock.when(() -> DirectoryIdBackup.backupManually(Mockito.any(), Mockito.any())).thenAnswer(Answers.RETURNS_SMART_NULLS);
 
-			result.fix(pathToVault, Mockito.mock(VaultConfig.class), Mockito.mock(Masterkey.class), cryptor);
+			result.fix(pathToVault, cryptor);
 
 			var expectedPath = pathToVault.resolve("d/ri/diculous-30-char-pseudo-hash");
 			ArgumentMatcher<CryptoPathMapper.CiphertextDirectory> cipherDirMatcher = obj -> obj.dirId.equals(dirId) && obj.path.endsWith(expectedPath);
@@ -69,7 +75,7 @@ public class MissingContentDirTest {
 			Mockito.doReturn(dirIdHash).when(fileNameCryptor).hashDirectoryId(dirId);
 			dirIdBackupMock.when(() -> DirectoryIdBackup.backupManually(Mockito.any(), Mockito.any())).thenThrow(new IOException("Access denied"));
 
-			Assertions.assertThrows(IOException.class, () -> result.fix(pathToVault, Mockito.mock(VaultConfig.class), Mockito.mock(Masterkey.class), cryptor));
+			Assertions.assertThrows(IOException.class, () -> result.fix(pathToVault, cryptor));
 		}
 	}
 }

--- a/src/test/java/org/cryptomator/cryptofs/health/dirid/MissingDirIdBackupTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/dirid/MissingDirIdBackupTest.java
@@ -5,6 +5,7 @@ import org.cryptomator.cryptofs.DirectoryIdBackup;
 import org.cryptomator.cryptofs.VaultConfig;
 import org.cryptomator.cryptolib.api.Cryptor;
 import org.cryptomator.cryptolib.api.Masterkey;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -19,6 +20,14 @@ public class MissingDirIdBackupTest {
 
 	@TempDir
 	public Path pathToVault;
+	private MissingDirIdBackup result;
+
+	@DisplayName("MissingDirIdBackup result has a fix")
+	@Test
+	public void testGetFix() {
+		result = new MissingDirIdBackup("foobar", Mockito.mock(Path.class));
+		Assertions.assertTrue(result.getFix(Mockito.mock(Path.class), Mockito.mock(VaultConfig.class), Mockito.mock(Masterkey.class), Mockito.mock(Cryptor.class)).isPresent());
+	}
 
 
 	@DisplayName("The fix calls dirId backup class with correct parameters")
@@ -30,8 +39,8 @@ public class MissingDirIdBackupTest {
 			dirIdBackupMock.when(() -> DirectoryIdBackup.backupManually(Mockito.any(), Mockito.any())).thenAnswer(Answers.RETURNS_SMART_NULLS);
 			Cryptor cryptor = Mockito.mock(Cryptor.class);
 
-			MissingDirIdBackup result = new MissingDirIdBackup(dirId, cipherDir);
-			result.fix(pathToVault, Mockito.mock(VaultConfig.class), Mockito.mock(Masterkey.class), cryptor);
+			result = new MissingDirIdBackup(dirId, cipherDir);
+			result.fix(pathToVault, cryptor);
 
 			var expectedPath = pathToVault.resolve("d").resolve(cipherDir);
 			ArgumentMatcher<CryptoPathMapper.CiphertextDirectory> cipherDirMatcher = obj -> obj.dirId.equals(dirId) && obj.path.isAbsolute() && obj.path.equals(expectedPath);

--- a/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/dirid/OrphanDirTest.java
@@ -64,6 +64,12 @@ public class OrphanDirTest {
 		Mockito.doReturn(fileNameCryptor).when(cryptor).fileNameCryptor();
 	}
 
+	@Test
+	@DisplayName("OrphanDir result has a fix")
+	public void testGetFix() {
+		Assertions.assertTrue(result.getFix(Mockito.mock(Path.class), Mockito.mock(VaultConfig.class), Mockito.mock(Masterkey.class), Mockito.mock(Cryptor.class)).isPresent());
+	}
+
 
 	@Nested
 	class PrepareRecoveryDirTests {

--- a/src/test/java/org/cryptomator/cryptofs/health/shortened/LongShortNamesMismatchTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/shortened/LongShortNamesMismatchTest.java
@@ -31,6 +31,13 @@ public class LongShortNamesMismatchTest {
 	}
 
 	@Test
+	@DisplayName("LongShortNamesMismatch result has a fix")
+	public void testGetFix() {
+		result = new LongShortNamesMismatch(Mockito.mock(Path.class), "bar==.c9s");
+		Assertions.assertTrue(result.getFix(Mockito.mock(Path.class), Mockito.mock(VaultConfig.class), Mockito.mock(Masterkey.class), Mockito.mock(Cryptor.class)).isPresent());
+	}
+
+	@Test
 	@DisplayName("a successful fix only renames the c9s directory")
 	public void testSuccessfulFixRenamesResource() throws IOException {
 		//prepare
@@ -40,7 +47,7 @@ public class LongShortNamesMismatchTest {
 		Files.createDirectory(c9sDir);
 
 		//execute
-		result.fix(pathToVault, Mockito.mock(VaultConfig.class), Mockito.mock(Masterkey.class), Mockito.mock(Cryptor.class));
+		result.fix(pathToVault);
 
 		//evaluate
 		Path expectedC9sDir = c9sDir.resolveSibling("bar==.c9s");

--- a/src/test/java/org/cryptomator/cryptofs/health/shortened/TrailingNullBytesInNameFileTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/health/shortened/TrailingNullBytesInNameFileTest.java
@@ -32,6 +32,13 @@ public class TrailingNullBytesInNameFileTest {
 		Files.createDirectories(cipherDir);
 	}
 
+	@DisplayName("TrailingNullBytes result has a fix")
+	@Test
+	public void testGetFix() {
+		result = new TrailingBytesInNameFile(Mockito.mock(Path.class), "foobar");
+		Assertions.assertTrue(result.getFix(Mockito.mock(Path.class), Mockito.mock(VaultConfig.class), Mockito.mock(Masterkey.class), Mockito.mock(Cryptor.class)).isPresent());
+	}
+
 	@Test
 	@DisplayName("Successful fix only removes trailing null bytes")
 	public void testSuccessfulFixRemovesTrailingNullBytes() throws IOException {
@@ -39,15 +46,15 @@ public class TrailingNullBytesInNameFileTest {
 		Path c9sDir = cipherDir.resolve("foo==.c9s");
 		Path nameFile = c9sDir.resolve("name.c9s");
 		var longName = "bar==.c9r\0\0\0";
-		result = new TrailingBytesInNameFile(nameFile, longName );
+		result = new TrailingBytesInNameFile(pathToVault.relativize(nameFile), longName);
 
 		Files.createDirectory(c9sDir);
 		Files.writeString(nameFile, longName, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
 
 		//execute
-		result.fix(pathToVault, Mockito.mock(VaultConfig.class), Mockito.mock(Masterkey.class), Mockito.mock(Cryptor.class));
+		result.fix(pathToVault);
 
 		//evaluate
-		Assertions.assertEquals("bar==.c9r", Files.readString(nameFile,StandardCharsets.UTF_8));
+		Assertions.assertEquals("bar==.c9r", Files.readString(nameFile, StandardCharsets.UTF_8));
 	}
 }


### PR DESCRIPTION
Currently, the (undocumented) convention for an implementaiton of `DiagnosticResult` is the following:
result severity  != `WARN` → do not override `fix()` method. (aka throws `UnsupportedOperationException`).

In the context of https://github.com/cryptomator/cryptofs/issues/128, this convention showed a lack of flexibility. The dirId backup file is an optional feature, but the result stating it's missing has a severity of `WARN` to be fixable.
Additionally, a lib consumer is unable to reach an intact vault structure once a critical error appears. This leads to reserved file paths, undeletable resources and other permament errors.

This PR solves those problems by discarding the aforementioned convention. The ideas are
* give the consumer the information she needs to make decisions
* provide tools to fix the vault structure and make the filesystem error free again
* only consider the current local state of the vault

The ideas are realized by decoupling the severity and the fix() method of a `DiagnosticResult` and change their meaning:
* The severity serves as an _indicator if the vault structure is compromised or data loss happened_. It does not make statements about if the result can be fixed/resolved.
* The fix method exists to _heal the vault structure_. More technically speaking,  it resolves the result by altering files and directories, such that the result is not triggered anymore by a subsequent run of the same health check. 

Implementationwise, the javadoc of `Severity` is adjusted. The feature to determine if a result fix exists is moved from convention to implementation: `DiagnosticResul::getFix` is a new method which returns `Optional<Fix>`, where the latter class is just a functional interface to apply the fix. The default implementation of `::getFix` returns an empty optional. To keep compatibility, method `fix(...)` still exists, but is deprecated. For existing results with fixes, a delegate method is implemented.
