### PR TITLE
Health check: Get affected fs nodes of result

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/health/api/DiagnosticResult.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/api/DiagnosticResult.java
@@ -87,7 +87,7 @@ public interface DiagnosticResult {
 	 *
 	 * @return a list of  paths pointing to affected fs nodes
 	 */
-	default List<Path> affectedCiphertextNodes() {
+	default List<Path> getCausingCiphertextNodes() {
 		return List.of();
 	}
 

--- a/src/main/java/org/cryptomator/cryptofs/health/api/DiagnosticResult.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/api/DiagnosticResult.java
@@ -6,6 +6,7 @@ import org.cryptomator.cryptolib.api.Masterkey;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -79,6 +80,15 @@ public interface DiagnosticResult {
 	 */
 	default Map<String, String> details() {
 		return Map.of();
+	}
+
+	/**
+	 * List all (ciphertext) filesystem nodes affected by this result
+	 *
+	 * @return a list of  paths pointing to affected fs nodes
+	 */
+	default List<Path> affectedCiphertextNodes() {
+		return List.of();
 	}
 
 	@FunctionalInterface

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/DirIdCollision.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/DirIdCollision.java
@@ -3,6 +3,7 @@ package org.cryptomator.cryptofs.health.dirid;
 import org.cryptomator.cryptofs.health.api.DiagnosticResult;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 
 import static org.cryptomator.cryptofs.health.api.CommonDetailKeys.DIR_ID;
@@ -38,5 +39,10 @@ public class DirIdCollision implements DiagnosticResult {
 		return Map.of(DIR_ID, dirId, //
 				DIR_FILE, dirFile.toString(), //
 				"Other " + DIR_FILE, otherDirFile.toString());
+	}
+
+	@Override
+	public List<Path> affectedCiphertextNodes(){
+		return List.of(dirFile, otherDirFile);
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/DirIdCollision.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/DirIdCollision.java
@@ -42,7 +42,7 @@ public class DirIdCollision implements DiagnosticResult {
 	}
 
 	@Override
-	public List<Path> affectedCiphertextNodes(){
+	public List<Path> getCausingCiphertextNodes(){
 		return List.of(dirFile, otherDirFile);
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/EmptyDirFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/EmptyDirFile.java
@@ -3,6 +3,7 @@ package org.cryptomator.cryptofs.health.dirid;
 import org.cryptomator.cryptofs.health.api.DiagnosticResult;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 
 import static org.cryptomator.cryptofs.health.api.CommonDetailKeys.DIR_FILE;
@@ -45,5 +46,10 @@ public class EmptyDirFile implements DiagnosticResult {
 	@Override
 	public Map<String, String> details() {
 		return Map.of(DIR_FILE, dirFile.toString());
+	}
+
+	@Override
+	public List<Path> affectedCiphertextNodes(){
+		return List.of(dirFile);
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/EmptyDirFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/EmptyDirFile.java
@@ -49,7 +49,7 @@ public class EmptyDirFile implements DiagnosticResult {
 	}
 
 	@Override
-	public List<Path> affectedCiphertextNodes(){
+	public List<Path> getCausingCiphertextNodes(){
 		return List.of(dirFile);
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/HealthyDir.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/HealthyDir.java
@@ -41,4 +41,9 @@ public class HealthyDir implements DiagnosticResult {
 				DIR_FILE, dirFile.toString(), //
 				ENCRYPTED_PATH, dir.toString());
 	}
+
+	@Override
+	public List<Path> affectedCiphertextNodes(){
+		return List.of(dirFile, dir);
+	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/HealthyDir.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/HealthyDir.java
@@ -43,7 +43,7 @@ public class HealthyDir implements DiagnosticResult {
 	}
 
 	@Override
-	public List<Path> affectedCiphertextNodes(){
+	public List<Path> getCausingCiphertextNodes(){
 		return List.of(dirFile, dir);
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/LooseDirFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/LooseDirFile.java
@@ -8,6 +8,7 @@ import org.cryptomator.cryptolib.api.Masterkey;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -47,5 +48,10 @@ public class LooseDirFile implements DiagnosticResult {
 	@Override
 	public Map<String, String> details() {
 		return Map.of(DIR_FILE, dirFile.toString());
+	}
+
+	@Override
+	public List<Path> affectedCiphertextNodes(){
+		return List.of(dirFile);
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/LooseDirFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/LooseDirFile.java
@@ -51,7 +51,7 @@ public class LooseDirFile implements DiagnosticResult {
 	}
 
 	@Override
-	public List<Path> affectedCiphertextNodes(){
+	public List<Path> getCausingCiphertextNodes(){
 		return List.of(dirFile);
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/MissingContentDir.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/MissingContentDir.java
@@ -11,6 +11,7 @@ import org.cryptomator.cryptolib.api.Masterkey;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -44,6 +45,11 @@ public class MissingContentDir implements DiagnosticResult {
 	public Map<String, String> details() {
 		return Map.of(DIR_ID, dirId, //
 				DIR_FILE, dirFile.toString());
+	}
+
+	@Override
+	public List<Path> affectedCiphertextNodes(){
+		return List.of(dirFile);
 	}
 
 	//visible for testing

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/MissingContentDir.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/MissingContentDir.java
@@ -48,7 +48,7 @@ public class MissingContentDir implements DiagnosticResult {
 	}
 
 	@Override
-	public List<Path> affectedCiphertextNodes(){
+	public List<Path> getCausingCiphertextNodes(){
 		return List.of(dirFile);
 	}
 

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/MissingDirIdBackup.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/MissingDirIdBackup.java
@@ -3,13 +3,13 @@ package org.cryptomator.cryptofs.health.dirid;
 import org.cryptomator.cryptofs.CryptoPathMapper;
 import org.cryptomator.cryptofs.DirectoryIdBackup;
 import org.cryptomator.cryptofs.VaultConfig;
-import org.cryptomator.cryptofs.common.Constants;
 import org.cryptomator.cryptofs.health.api.DiagnosticResult;
 import org.cryptomator.cryptolib.api.Cryptor;
 import org.cryptomator.cryptolib.api.Masterkey;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -25,6 +25,11 @@ public record MissingDirIdBackup(String dirId, Path contentDir) implements Diagn
 	@Override
 	public String toString() {
 		return String.format("Directory ID backup for directory %s is missing.", contentDir);
+	}
+
+	@Override
+	public List<Path> affectedCiphertextNodes() {
+		return List.of(contentDir);
 	}
 
 	//visible for testing

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/MissingDirIdBackup.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/MissingDirIdBackup.java
@@ -28,7 +28,7 @@ public record MissingDirIdBackup(String dirId, Path contentDir) implements Diagn
 	}
 
 	@Override
-	public List<Path> affectedCiphertextNodes() {
+	public List<Path> getCausingCiphertextNodes() {
 		return List.of(contentDir);
 	}
 

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/ObeseDirFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/ObeseDirFile.java
@@ -39,7 +39,7 @@ public class ObeseDirFile implements DiagnosticResult {
 	}
 
 	@Override
-	public List<Path> affectedCiphertextNodes(){
+	public List<Path> getCausingCiphertextNodes(){
 		return List.of(dirFile);
 	}
 	// potential fix: assign new dir id, move target dir

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/ObeseDirFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/ObeseDirFile.java
@@ -4,6 +4,7 @@ import org.cryptomator.cryptofs.common.Constants;
 import org.cryptomator.cryptofs.health.api.DiagnosticResult;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 
 import static org.cryptomator.cryptofs.health.api.CommonDetailKeys.DIR_FILE;
@@ -35,6 +36,11 @@ public class ObeseDirFile implements DiagnosticResult {
 	public Map<String, String> details() {
 		return Map.of(DIR_FILE, dirFile.toString(), //
 				"Size", Long.toString(size));
+	}
+
+	@Override
+	public List<Path> affectedCiphertextNodes(){
+		return List.of(dirFile);
 	}
 	// potential fix: assign new dir id, move target dir
 

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanContentDir.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanContentDir.java
@@ -74,7 +74,7 @@ public class OrphanContentDir implements DiagnosticResult {
 	}
 
 	@Override
-	public List<Path> affectedCiphertextNodes(){
+	public List<Path> getCausingCiphertextNodes(){
 		return List.of(contentDir);
 	}
 

--- a/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanContentDir.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/dirid/OrphanContentDir.java
@@ -27,6 +27,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -70,6 +71,11 @@ public class OrphanContentDir implements DiagnosticResult {
 	@Override
 	public Optional<Fix> getFix(Path pathToVault, VaultConfig config, Masterkey masterkey, Cryptor cryptor) {
 		return Optional.of(() -> fix(pathToVault, config, cryptor));
+	}
+
+	@Override
+	public List<Path> affectedCiphertextNodes(){
+		return List.of(contentDir);
 	}
 
 	private void fix(Path pathToVault, VaultConfig config, Cryptor cryptor) throws IOException {

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/LongShortNamesMismatch.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/LongShortNamesMismatch.java
@@ -36,7 +36,7 @@ public class LongShortNamesMismatch implements DiagnosticResult {
 
 
 	@Override
-	public List<Path> affectedCiphertextNodes(){
+	public List<Path> getCausingCiphertextNodes(){
 		return List.of(c9sDir);
 	}
 

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/LongShortNamesMismatch.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/LongShortNamesMismatch.java
@@ -8,6 +8,7 @@ import org.cryptomator.cryptolib.api.Masterkey;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -31,6 +32,12 @@ public class LongShortNamesMismatch implements DiagnosticResult {
 	@Override
 	public String toString() {
 		return String.format("Name of %s is not a base64url encoded SHA1 hash of String inside name.c9s.", c9sDir);
+	}
+
+
+	@Override
+	public List<Path> affectedCiphertextNodes(){
+		return List.of(c9sDir);
 	}
 
 	// fix by renaming the parent to the content of name.c9s

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/MissingLongName.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/MissingLongName.java
@@ -32,7 +32,7 @@ public class MissingLongName implements DiagnosticResult {
 	}
 
 	@Override
-	public List<Path> affectedCiphertextNodes(){
+	public List<Path> getCausingCiphertextNodes(){
 		return List.of(c9sDir);
 	}
 

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/MissingLongName.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/MissingLongName.java
@@ -4,6 +4,7 @@ import org.cryptomator.cryptofs.common.Constants;
 import org.cryptomator.cryptofs.health.api.DiagnosticResult;
 
 import java.nio.file.Path;
+import java.util.List;
 
 /**
  * A c9s directory with a missing long name.
@@ -28,6 +29,11 @@ public class MissingLongName implements DiagnosticResult {
 	@Override
 	public String toString() {
 		return String.format("Shortened resource %s either misses %s or the file has invalid content.", c9sDir, Constants.INFLATED_FILE_NAME);
+	}
+
+	@Override
+	public List<Path> affectedCiphertextNodes(){
+		return List.of(c9sDir);
 	}
 
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/NotDecodableLongName.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/NotDecodableLongName.java
@@ -48,7 +48,7 @@ public class NotDecodableLongName implements DiagnosticResult {
 	}
 
 	@Override
-	public List<Path> affectedCiphertextNodes(){
+	public List<Path> getCausingCiphertextNodes(){
 		return List.of(nameFile);
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/NotDecodableLongName.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/NotDecodableLongName.java
@@ -4,6 +4,7 @@ import org.cryptomator.cryptofs.health.api.CommonDetailKeys;
 import org.cryptomator.cryptofs.health.api.DiagnosticResult;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -44,5 +45,10 @@ public class NotDecodableLongName implements DiagnosticResult {
 	@Override
 	public String toString() {
 		return String.format("String \"%s\" stored in %s is not a valid Cryptomator filename.", longName, nameFile);
+	}
+
+	@Override
+	public List<Path> affectedCiphertextNodes(){
+		return List.of(nameFile);
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/ObeseNameFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/ObeseNameFile.java
@@ -30,7 +30,7 @@ public class ObeseNameFile implements DiagnosticResult {
 	}
 
 	@Override
-	public List<Path> affectedCiphertextNodes(){
+	public List<Path> getCausingCiphertextNodes(){
 		return List.of(nameFile);
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/ObeseNameFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/ObeseNameFile.java
@@ -4,6 +4,7 @@ import org.cryptomator.cryptofs.LongFileNameProvider;
 import org.cryptomator.cryptofs.health.api.DiagnosticResult;
 
 import java.nio.file.Path;
+import java.util.List;
 
 /**
  * A shortend file name file which exceeds the maximum size of {@value org.cryptomator.cryptofs.LongFileNameProvider#MAX_FILENAME_BUFFER_SIZE} bytes.
@@ -28,4 +29,8 @@ public class ObeseNameFile implements DiagnosticResult {
 		return String.format("Long filename file %s with size %d exceeds limit of %d for this type.", nameFile, size, LongFileNameProvider.MAX_FILENAME_BUFFER_SIZE);
 	}
 
+	@Override
+	public List<Path> affectedCiphertextNodes(){
+		return List.of(nameFile);
+	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/TrailingBytesInNameFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/TrailingBytesInNameFile.java
@@ -61,7 +61,7 @@ public class TrailingBytesInNameFile implements DiagnosticResult {
 	}
 
 	@Override
-	public List<Path> affectedCiphertextNodes(){
+	public List<Path> getCausingCiphertextNodes(){
 		return List.of(nameFile);
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/TrailingBytesInNameFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/TrailingBytesInNameFile.java
@@ -11,6 +11,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -57,5 +58,10 @@ public class TrailingBytesInNameFile implements DiagnosticResult {
 	@Override
 	public String toString() {
 		return String.format("Encrypted filename \"%s\" stored in %s contains trailing bytes.", longName, nameFile);
+	}
+
+	@Override
+	public List<Path> affectedCiphertextNodes(){
+		return List.of(nameFile);
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/ValidShortenedFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/ValidShortenedFile.java
@@ -3,6 +3,7 @@ package org.cryptomator.cryptofs.health.shortened;
 import org.cryptomator.cryptofs.health.api.DiagnosticResult;
 
 import java.nio.file.Path;
+import java.util.List;
 
 /**
  * A valid shortened resource according to the Cryptomator vault specification.
@@ -23,4 +24,8 @@ public class ValidShortenedFile implements DiagnosticResult {
 		return String.format("Found valid shortened resource at %s.", c9sDir);
 	}
 
+	@Override
+	public List<Path> affectedCiphertextNodes(){
+		return List.of(c9sDir);
+	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/shortened/ValidShortenedFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/shortened/ValidShortenedFile.java
@@ -25,7 +25,7 @@ public class ValidShortenedFile implements DiagnosticResult {
 	}
 
 	@Override
-	public List<Path> affectedCiphertextNodes(){
+	public List<Path> getCausingCiphertextNodes(){
 		return List.of(c9sDir);
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/type/AmbiguousType.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/type/AmbiguousType.java
@@ -39,7 +39,7 @@ public class AmbiguousType implements DiagnosticResult {
 	}
 
 	@Override
-	public List<Path> affectedCiphertextNodes(){
+	public List<Path> getCausingCiphertextNodes(){
 		return List.of(cipherDir);
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/type/AmbiguousType.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/type/AmbiguousType.java
@@ -5,6 +5,7 @@ import org.cryptomator.cryptofs.health.api.CommonDetailKeys;
 import org.cryptomator.cryptofs.health.api.DiagnosticResult;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -35,5 +36,10 @@ public class AmbiguousType implements DiagnosticResult {
 	public Map<String, String> details() {
 		return Map.of(CommonDetailKeys.ENCRYPTED_PATH, cipherDir.toString(),
 				"Possible Types", possibleTypes.toString());
+	}
+
+	@Override
+	public List<Path> affectedCiphertextNodes(){
+		return List.of(cipherDir);
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/type/KnownType.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/type/KnownType.java
@@ -38,7 +38,7 @@ public class KnownType implements DiagnosticResult {
 	}
 
 	@Override
-	public List<Path> affectedCiphertextNodes(){
+	public List<Path> getCausingCiphertextNodes(){
 		return List.of(cipherDir);
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/type/KnownType.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/type/KnownType.java
@@ -5,6 +5,7 @@ import org.cryptomator.cryptofs.health.api.CommonDetailKeys;
 import org.cryptomator.cryptofs.health.api.DiagnosticResult;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -34,5 +35,10 @@ public class KnownType implements DiagnosticResult {
 	public Map<String, String> details() {
 		return Map.of(CommonDetailKeys.ENCRYPTED_PATH, cipherDir.toString(),
 				"Type", type.name());
+	}
+
+	@Override
+	public List<Path> affectedCiphertextNodes(){
+		return List.of(cipherDir);
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/type/UnknownType.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/type/UnknownType.java
@@ -52,7 +52,7 @@ public class UnknownType implements DiagnosticResult {
 	}
 
 	@Override
-	public List<Path> affectedCiphertextNodes(){
+	public List<Path> getCausingCiphertextNodes(){
 		return List.of(cipherDir);
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/health/type/UnknownType.java
+++ b/src/main/java/org/cryptomator/cryptofs/health/type/UnknownType.java
@@ -10,6 +10,7 @@ import org.cryptomator.cryptolib.api.Masterkey;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -50,4 +51,8 @@ public class UnknownType implements DiagnosticResult {
 		return Map.of(CommonDetailKeys.ENCRYPTED_PATH, cipherDir.toString());
 	}
 
+	@Override
+	public List<Path> affectedCiphertextNodes(){
+		return List.of(cipherDir);
+	}
 }


### PR DESCRIPTION
This PR adds the method `getCausingCiphertextNodes()` to the interface `DiagnosticResult`.

The method is intended to list ciphertext resources, which triggered the concrete result.