### PR TITLE
Feature: Add function to get (data) ciphertext path from cleartext path

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystem.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystem.java
@@ -1,5 +1,6 @@
 package org.cryptomator.cryptofs;
 
+import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -28,6 +29,15 @@ public abstract class CryptoFileSystem extends FileSystem {
 	 * @return the {@link Path} to the directory containing the encrypted files.
 	 */
 	public abstract Path getPathToVault();
+
+	/**
+	 * Provides the {@link Path} to the ciphertext from a given cleartext path.
+	 *
+	 * @param cleartextPath the path to the cleartext file or folder belonging to this {@code CryptoFileSystem}, which internally is a {@code CryptoPath}
+	 * @return the {@link Path} to ciphertext file or folder
+	 * @throws IOException
+	 */
+	public abstract Path getPathToCiphertext(Path cleartextPath) throws IOException;
 
 	/**
 	 * Provides file system performance statistics.

--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystem.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystem.java
@@ -31,13 +31,13 @@ public abstract class CryptoFileSystem extends FileSystem {
 	public abstract Path getPathToVault();
 
 	/**
-	 * Provides the {@link Path} to the ciphertext from a given cleartext path.
+	 * Provides the {@link Path} to the (data) ciphertext from a given cleartext path.
 	 *
-	 * @param cleartextPath the path to the cleartext file or folder belonging to this {@code CryptoFileSystem}, which internally is a {@code CryptoPath}
-	 * @return the {@link Path} to ciphertext file or folder
+	 * @param cleartextPath path to the cleartext file or folder belonging to this {@link CryptoFileSystem}. Internally the path must be an instance of {@link CryptoPath}
+	 * @return the {@link Path} to ciphertext file or folder containing teh actual encrypted data
 	 * @throws IOException
 	 */
-	public abstract Path getPathToCiphertext(Path cleartextPath) throws IOException;
+	public abstract Path getPathToDataCiphertext(Path cleartextPath) throws IOException;
 
 	/**
 	 * Provides file system performance statistics.

--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystem.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystem.java
@@ -33,7 +33,7 @@ public abstract class CryptoFileSystem extends FileSystem {
 	/**
 	 * Provides the {@link Path} to the (data) ciphertext from a given cleartext path.
 	 *
-	 * @param cleartextPath path to the cleartext file or folder belonging to this {@link CryptoFileSystem}. Internally the path must be an instance of {@link CryptoPath}
+	 * @param cleartextPath absolute path to the cleartext file or folder belonging to this {@link CryptoFileSystem}. Internally the path must be an instance of {@link CryptoPath}
 	 * @return the {@link Path} to ciphertext file or folder containing teh actual encrypted data
 	 * @throws IOException
 	 */

--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemImpl.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemImpl.java
@@ -137,12 +137,16 @@ class CryptoFileSystemImpl extends CryptoFileSystem {
 	}
 
 	@Override
-	public Path getPathToCiphertext(Path cleartextPath) throws IOException {
-		var cryptoPath = CryptoPath.cast(cleartextPath);
-		if (Files.isDirectory(cleartextPath)) {
-			return cryptoPathMapper.getCiphertextDir(cryptoPath).path;
+	public Path getPathToDataCiphertext(Path cleartextPath) throws IOException {
+		var p = CryptoPath.castAndAssertAbsolute(cleartextPath);
+		var nodeType = cryptoPathMapper.getCiphertextFileType(p);
+		var cipherFile = cryptoPathMapper.getCiphertextFilePath(p);
+		if( nodeType == CiphertextFileType.DIRECTORY) {
+			return cryptoPathMapper.getCiphertextDir(p).path;
+		} else if( nodeType == CiphertextFileType.SYMLINK) {
+			return cipherFile.getSymlinkFilePath();
 		} else {
-			return cryptoPathMapper.getCiphertextFilePath(cryptoPath).getRawPath();
+			return cipherFile.getFilePath();
 		}
 	}
 

--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemImpl.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemImpl.java
@@ -137,6 +137,16 @@ class CryptoFileSystemImpl extends CryptoFileSystem {
 	}
 
 	@Override
+	public Path getPathToCiphertext(Path cleartextPath) throws IOException {
+		var cryptoPath = CryptoPath.cast(cleartextPath);
+		if (Files.isDirectory(cleartextPath)) {
+			return cryptoPathMapper.getCiphertextDir(cryptoPath).path;
+		} else {
+			return cryptoPathMapper.getCiphertextFilePath(cryptoPath).getRawPath();
+		}
+	}
+
+	@Override
 	public CryptoFileSystemStats getStats() {
 		return stats;
 	}

--- a/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemImplTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemImplTest.java
@@ -42,6 +42,7 @@ import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
+import java.nio.file.ProviderMismatchException;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributeView;
@@ -119,11 +120,11 @@ public class CryptoFileSystemImplTest {
 
 		when(fileSystemProperties.maxCleartextNameLength()).thenReturn(32768);
 
-		inTest = new CryptoFileSystemImpl(provider, cryptoFileSystems, pathToVault, cryptor,
-				fileStore, stats, cryptoPathMapper, cryptoPathFactory,
-				pathMatcherFactory, directoryStreamFactory, dirIdProvider, dirIdBackup,
-				fileAttributeProvider, fileAttributeByNameProvider, fileAttributeViewProvider,
-				openCryptoFiles, symlinks, finallyUtil, ciphertextDirDeleter, readonlyFlag,
+		inTest = new CryptoFileSystemImpl(provider, cryptoFileSystems, pathToVault, cryptor, //
+				fileStore, stats, cryptoPathMapper, cryptoPathFactory, //
+				pathMatcherFactory, directoryStreamFactory, dirIdProvider, dirIdBackup, //
+				fileAttributeProvider, fileAttributeByNameProvider, fileAttributeViewProvider, //
+				openCryptoFiles, symlinks, finallyUtil, ciphertextDirDeleter, readonlyFlag, //
 				fileSystemProperties);
 	}
 
@@ -186,6 +187,89 @@ public class CryptoFileSystemImplTest {
 	@Test
 	public void testGetFileStoresReturnsFileStore() {
 		Assertions.assertSame(fileStore, inTest.getFileStore());
+	}
+
+	@Nested
+	public class PathToDataCiphertext {
+
+		@Test
+		@DisplayName("Getting data ciphertext path of directory returns ciphertext content dir")
+		public void testCleartextDirectory() throws IOException {
+			Path ciphertext = Mockito.mock(Path.class, "/d/AB/CD...XYZ/");
+			Path cleartext = inTest.getPath("/");
+			try (var cryptoPathMock = Mockito.mockStatic(CryptoPath.class)) {
+				cryptoPathMock.when(() -> CryptoPath.castAndAssertAbsolute(any())).thenReturn(cleartext);
+				when(cryptoPathMapper.getCiphertextFileType(any())).thenReturn(CiphertextFileType.DIRECTORY);
+				when(cryptoPathMapper.getCiphertextDir(any())).thenReturn(new CiphertextDirectory("foo", ciphertext));
+
+				Path result = inTest.getPathToDataCiphertext(cleartext);
+				Assertions.assertEquals(ciphertext, result);
+			}
+		}
+
+		@Test
+		@DisplayName("Getting data ciphertext path of file returns ciphertext file")
+		public void testCleartextFile() throws IOException {
+			Path ciphertext = Mockito.mock(Path.class, "/d/AB/CD..XYZ/foo.c9r");
+			Path cleartext = inTest.getPath("/foo.bar");
+			try (var cryptoPathMock = Mockito.mockStatic(CryptoPath.class)) {
+				CiphertextFilePath p = Mockito.mock(CiphertextFilePath.class);
+				cryptoPathMock.when(() -> CryptoPath.castAndAssertAbsolute(any())).thenReturn(cleartext);
+				when(cryptoPathMapper.getCiphertextFileType(any())).thenReturn(CiphertextFileType.FILE);
+				when(cryptoPathMapper.getCiphertextFilePath(any())).thenReturn(p);
+				when(p.getFilePath()).thenReturn(ciphertext);
+
+				Path result = inTest.getPathToDataCiphertext(cleartext);
+				Assertions.assertEquals(ciphertext, result);
+			}
+		}
+
+		@Test
+		@DisplayName("Getting data ciphertext path of symlink returns ciphertext symlink.c9r")
+		public void testCleartextSymlink() throws IOException {
+			Path ciphertext = Mockito.mock(Path.class, "/d/AB/CD..XYZ/foo.c9s/symlink.c9r");
+			Path cleartext = inTest.getPath("/foo.bar");
+			try (var cryptoPathMock = Mockito.mockStatic(CryptoPath.class)) {
+				CiphertextFilePath p = Mockito.mock(CiphertextFilePath.class);
+				cryptoPathMock.when(() -> CryptoPath.castAndAssertAbsolute(any())).thenReturn(cleartext);
+				when(cryptoPathMapper.getCiphertextFileType(any())).thenReturn(CiphertextFileType.SYMLINK);
+				when(cryptoPathMapper.getCiphertextFilePath(any())).thenReturn(p);
+				when(p.getSymlinkFilePath()).thenReturn(ciphertext);
+
+				Path result = inTest.getPathToDataCiphertext(cleartext);
+				Assertions.assertEquals(ciphertext, result);
+			}
+		}
+
+		@Test
+		@DisplayName("Path not pointing into the vault throws exception")
+		public void testForeignPathThrows() throws IOException {
+			Path cleartext = Mockito.mock(Path.class, "/some.file");
+			Assertions.assertThrows(ProviderMismatchException.class, () -> inTest.getPathToDataCiphertext(cleartext));
+		}
+
+		@Test
+		@DisplayName("Not existing resource throws NoSuchFileException")
+		public void testNoSuchFile() throws IOException {
+			Path cleartext = inTest.getPath("/i-do-not-exist");
+			try (var cryptoPathMock = Mockito.mockStatic(CryptoPath.class)) {
+				cryptoPathMock.when(() -> CryptoPath.castAndAssertAbsolute(any())).thenReturn(cleartext);
+				when(cryptoPathMapper.getCiphertextFileType(any())).thenThrow(new NoSuchFileException("no such file"));
+
+				Assertions.assertThrows(NoSuchFileException.class, () -> inTest.getPathToDataCiphertext(cleartext));
+			}
+		}
+
+		@Test
+		@DisplayName("Relative cleartext path throws exception")
+		public void testRelativePathException() throws IOException {
+			Path cleartext = inTest.getPath("relative/path");
+			try (var cryptoPathMock = Mockito.mockStatic(CryptoPath.class)) {
+				cryptoPathMock.when(() -> CryptoPath.castAndAssertAbsolute(any())).thenThrow(new IllegalArgumentException());
+
+				Assertions.assertThrows(IllegalArgumentException.class, () -> inTest.getPathToDataCiphertext(cleartext));
+			}
+		}
 	}
 
 	@Nested


### PR DESCRIPTION
This PR adds to the CryptoFilesystem interface the following function: 
`Path getPathToDataCiphertext(Path cleartextPath) throws IOException`

The function returns for a given, absolute cleartext path belonging to this cryptofilesystem its ciphertext data counterpart. It does not point to intermediante files like dir.c9r. This means:
* regular file `/file.file` → `/d/AB/CD...XYZ/foo.c9r`
* shortend file `/very...long.name` → `/d/AB/CD...XYZ/foo.c9s/contents.c9r`
* directory `/directory` → `/d/AB/CD...XYZ/`
* symlink `/sym.link` → `/d/AB/CD...XYZ/foo.c9r/symlink.c9r`

If the fs node does not exists or another exception is thrown, it is propageted.
