### PR TITLE
Support for encrypted UserDefinedAttributeView

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/attr/AbstractCryptoFileAttributeView.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/AbstractCryptoFileAttributeView.java
@@ -20,7 +20,7 @@ import java.nio.file.Path;
 import java.nio.file.attribute.FileAttributeView;
 
 abstract sealed class AbstractCryptoFileAttributeView implements FileAttributeView
-		permits CryptoBasicFileAttributeView, CryptoFileOwnerAttributeView, CryptoUserDefinedAttributeView {
+		permits CryptoBasicFileAttributeView, CryptoFileOwnerAttributeView, CryptoUserDefinedFileAttributeView {
 
 	protected final CryptoPath cleartextPath;
 	private final CryptoPathMapper pathMapper;

--- a/src/main/java/org/cryptomator/cryptofs/attr/AbstractCryptoFileAttributeView.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/AbstractCryptoFileAttributeView.java
@@ -13,30 +13,26 @@ import org.cryptomator.cryptofs.CryptoPathMapper;
 import org.cryptomator.cryptofs.Symlinks;
 import org.cryptomator.cryptofs.common.ArrayUtils;
 import org.cryptomator.cryptofs.common.CiphertextFileType;
-import org.cryptomator.cryptofs.fh.OpenCryptoFile;
-import org.cryptomator.cryptofs.fh.OpenCryptoFiles;
 
 import java.io.IOException;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileAttributeView;
-import java.util.Optional;
 
 abstract sealed class AbstractCryptoFileAttributeView implements FileAttributeView
-		permits CryptoBasicFileAttributeView, CryptoFileOwnerAttributeView {
+		permits CryptoBasicFileAttributeView, CryptoFileOwnerAttributeView, CryptoUserDefinedAttributeView {
 
 	protected final CryptoPath cleartextPath;
 	private final CryptoPathMapper pathMapper;
 	protected final LinkOption[] linkOptions;
 	private final Symlinks symlinks;
-	private final OpenCryptoFiles openCryptoFiles;
 
-	protected AbstractCryptoFileAttributeView(CryptoPath cleartextPath, CryptoPathMapper pathMapper, LinkOption[] linkOptions, Symlinks symlinks, OpenCryptoFiles openCryptoFiles) {
+
+	protected AbstractCryptoFileAttributeView(CryptoPath cleartextPath, CryptoPathMapper pathMapper, LinkOption[] linkOptions, Symlinks symlinks) {
 		this.cleartextPath = cleartextPath;
 		this.pathMapper = pathMapper;
 		this.linkOptions = linkOptions;
 		this.symlinks = symlinks;
-		this.openCryptoFiles = openCryptoFiles;
 	}
 
 	protected <T extends FileAttributeView> T getCiphertextAttributeView(Class<T> delegateType) throws IOException {
@@ -44,12 +40,7 @@ abstract sealed class AbstractCryptoFileAttributeView implements FileAttributeVi
 		return ciphertextPath.getFileSystem().provider().getFileAttributeView(ciphertextPath, delegateType);
 	}
 
-	protected Optional<OpenCryptoFile> getOpenCryptoFile() throws IOException {
-		Path ciphertextPath = getCiphertextPath(cleartextPath);
-		return openCryptoFiles.get(ciphertextPath);
-	}
-
-	private Path getCiphertextPath(CryptoPath path) throws IOException {
+	protected Path getCiphertextPath(CryptoPath path) throws IOException {
 		CiphertextFileType type = pathMapper.getCiphertextFileType(path);
 		return switch (type) {
 			case SYMLINK:

--- a/src/main/java/org/cryptomator/cryptofs/attr/AttributeViewModule.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/AttributeViewModule.java
@@ -44,9 +44,9 @@ abstract class AttributeViewModule {
 
 	@Binds
 	@IntoMap
-	@ClassKey(CryptoUserDefinedAttributeView.class)
+	@ClassKey(CryptoUserDefinedFileAttributeView.class)
 	@AttributeViewScoped
-	public abstract FileAttributeView provideUserDefinedAttributeView(CryptoUserDefinedAttributeView view);
+	public abstract FileAttributeView provideUserDefinedAttributeView(CryptoUserDefinedFileAttributeView view);
 
 	@Provides
 	@AttributeViewScoped

--- a/src/main/java/org/cryptomator/cryptofs/attr/AttributeViewModule.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/AttributeViewModule.java
@@ -42,6 +42,12 @@ abstract class AttributeViewModule {
 	@AttributeViewScoped
 	public abstract FileAttributeView provideFileOwnerAttributeView(CryptoFileOwnerAttributeView view);
 
+	@Binds
+	@IntoMap
+	@ClassKey(CryptoUserDefinedAttributeView.class)
+	@AttributeViewScoped
+	public abstract FileAttributeView provideUserDefinedAttributeView(CryptoUserDefinedAttributeView view);
+
 	@Provides
 	@AttributeViewScoped
 	public static Optional<FileAttributeView> provideAttributeView(Map<Class<?>, Provider<FileAttributeView>> providers, Class<? extends FileAttributeView> requestedType) {

--- a/src/main/java/org/cryptomator/cryptofs/attr/AttributeViewModule.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/AttributeViewModule.java
@@ -12,6 +12,7 @@ import java.nio.file.attribute.DosFileAttributeView;
 import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.FileOwnerAttributeView;
 import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.UserDefinedFileAttributeView;
 import java.util.Map;
 import java.util.Optional;
 
@@ -44,7 +45,7 @@ abstract class AttributeViewModule {
 
 	@Binds
 	@IntoMap
-	@ClassKey(CryptoUserDefinedFileAttributeView.class)
+	@ClassKey(UserDefinedFileAttributeView.class)
 	@AttributeViewScoped
 	public abstract FileAttributeView provideUserDefinedAttributeView(CryptoUserDefinedFileAttributeView view);
 

--- a/src/main/java/org/cryptomator/cryptofs/attr/AttributeViewType.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/AttributeViewType.java
@@ -5,6 +5,7 @@ import java.nio.file.attribute.DosFileAttributeView;
 import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.FileOwnerAttributeView;
 import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.UserDefinedFileAttributeView;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -12,7 +13,8 @@ public enum AttributeViewType {
 	BASIC(BasicFileAttributeView.class, "basic"),
 	OWNER(FileOwnerAttributeView.class, "owner"),
 	POSIX(PosixFileAttributeView.class, "posix"),
-	DOS(DosFileAttributeView.class, "dos");
+	DOS(DosFileAttributeView.class, "dos"),
+	USER(UserDefinedFileAttributeView.class, "user");
 
 	private final Class<? extends FileAttributeView> type;
 	private final String viewName;

--- a/src/main/java/org/cryptomator/cryptofs/attr/CryptoFileOwnerAttributeView.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/CryptoFileOwnerAttributeView.java
@@ -26,8 +26,8 @@ final class CryptoFileOwnerAttributeView extends AbstractCryptoFileAttributeView
 	private final ReadonlyFlag readonlyFlag;
 
 	@Inject
-	public CryptoFileOwnerAttributeView(CryptoPath cleartextPath, CryptoPathMapper pathMapper, LinkOption[] linkOptions, Symlinks symlinks, OpenCryptoFiles openCryptoFiles, ReadonlyFlag readonlyFlag) {
-		super(cleartextPath, pathMapper, linkOptions, symlinks, openCryptoFiles);
+	public CryptoFileOwnerAttributeView(CryptoPath cleartextPath, CryptoPathMapper pathMapper, LinkOption[] linkOptions, Symlinks symlinks, ReadonlyFlag readonlyFlag) {
+		super(cleartextPath, pathMapper, linkOptions, symlinks);
 		this.readonlyFlag = readonlyFlag;
 	}
 

--- a/src/main/java/org/cryptomator/cryptofs/attr/CryptoUserDefinedAttributeView.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/CryptoUserDefinedAttributeView.java
@@ -1,0 +1,122 @@
+package org.cryptomator.cryptofs.attr;
+
+import com.google.common.io.BaseEncoding;
+import org.cryptomator.cryptofs.CryptoPath;
+import org.cryptomator.cryptofs.CryptoPathMapper;
+import org.cryptomator.cryptofs.Symlinks;
+import org.cryptomator.cryptolib.api.Cryptor;
+import org.cryptomator.cryptolib.common.DecryptingReadableByteChannel;
+import org.cryptomator.cryptolib.common.EncryptingWritableByteChannel;
+
+import javax.inject.Inject;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.file.LinkOption;
+import java.nio.file.attribute.UserDefinedFileAttributeView;
+import java.util.List;
+
+@AttributeViewScoped
+final class CryptoUserDefinedAttributeView extends AbstractCryptoFileAttributeView implements UserDefinedFileAttributeView {
+
+	private static final String PREFIX = "c9r.";
+
+	private final Cryptor cryptor;
+
+	@Inject
+	public CryptoUserDefinedAttributeView(CryptoPath cleartextPath, CryptoPathMapper pathMapper, LinkOption[] linkOptions, Symlinks symlinks, Cryptor cryptor) {
+		super(cleartextPath, pathMapper, linkOptions, symlinks);
+		this.cryptor = cryptor;
+	}
+
+	@Override
+	public String name() {
+		return "user"; // as per contract
+	}
+
+	@Override
+	public List<String> list() throws IOException {
+		var ciphertextNames = getCiphertextAttributeView(UserDefinedFileAttributeView.class).list();
+		return ciphertextNames.stream().filter(s -> s.startsWith(PREFIX)).map(this::decryptName).toList();
+	}
+
+	@Override
+	public int size(String cleartextName) throws IOException {
+		var ciphertextName = encryptName(cleartextName);
+		return getCiphertextAttributeView(UserDefinedFileAttributeView.class).size(ciphertextName);
+	}
+
+	@Override
+	public int read(String cleartextName, ByteBuffer dst) throws IOException {
+		var ciphertextName = encryptName(cleartextName);
+		var view = getCiphertextAttributeView(UserDefinedFileAttributeView.class);
+		int size = view.size(ciphertextName);
+		var buf = ByteBuffer.allocate(size);
+		view.read(ciphertextName, buf);
+		buf.flip();
+
+		try (var in = new ByteBufferInputStream(buf); //
+			 var ciphertextChannel = Channels.newChannel(in); //
+			 var cleartextChannel = new DecryptingReadableByteChannel(ciphertextChannel, cryptor, true)) {
+			return cleartextChannel.read(dst);
+		}
+	}
+
+	@Override
+	public int write(String cleartextName, ByteBuffer src) throws IOException {
+		var ciphertextName = encryptName(cleartextName);
+		try (var out = new ByteArrayOutputStream();
+			 var ciphertextChannel = Channels.newChannel(out); //
+			 var cleartextChannel = new EncryptingWritableByteChannel(ciphertextChannel, cryptor)) {
+			int size = cleartextChannel.write(src);
+			var buf = ByteBuffer.wrap(out.toByteArray());
+			getCiphertextAttributeView(UserDefinedFileAttributeView.class).write(ciphertextName, buf);
+			return size;
+		}
+	}
+
+	@Override
+	public void delete(String cleartextName) throws IOException {
+		var ciphertextName = encryptName(cleartextName);
+		getCiphertextAttributeView(UserDefinedFileAttributeView.class).delete(ciphertextName);
+	}
+
+	private String encryptName(String cleartextName) {
+		return PREFIX + cryptor.fileNameCryptor().encryptFilename(BaseEncoding.base64Url(), cleartextName);
+	}
+
+	private String decryptName(String ciphertextName) {
+		assert ciphertextName.startsWith(PREFIX);
+		return cryptor.fileNameCryptor().decryptFilename(BaseEncoding.base64Url(), ciphertextName.substring(PREFIX.length()));
+	}
+
+	// taken from https://stackoverflow.com/a/6603018/4014509
+	private static class ByteBufferInputStream extends InputStream {
+
+		ByteBuffer buf;
+
+		public ByteBufferInputStream(ByteBuffer buf) {
+			this.buf = buf;
+		}
+
+		public int read() throws IOException {
+			if (!buf.hasRemaining()) {
+				return -1;
+			}
+			return buf.get() & 0xFF;
+		}
+
+		public int read(byte[] bytes, int off, int len) throws IOException {
+			if (!buf.hasRemaining()) {
+				return -1;
+			}
+
+			len = Math.min(len, buf.remaining());
+			buf.get(bytes, off, len);
+			return len;
+		}
+	}
+
+}

--- a/src/main/java/org/cryptomator/cryptofs/attr/CryptoUserDefinedFileAttributeView.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/CryptoUserDefinedFileAttributeView.java
@@ -19,14 +19,14 @@ import java.nio.file.attribute.UserDefinedFileAttributeView;
 import java.util.List;
 
 @AttributeViewScoped
-final class CryptoUserDefinedAttributeView extends AbstractCryptoFileAttributeView implements UserDefinedFileAttributeView {
+final class CryptoUserDefinedFileAttributeView extends AbstractCryptoFileAttributeView implements UserDefinedFileAttributeView {
 
 	private static final String PREFIX = "c9r.";
 
 	private final Cryptor cryptor;
 
 	@Inject
-	public CryptoUserDefinedAttributeView(CryptoPath cleartextPath, CryptoPathMapper pathMapper, LinkOption[] linkOptions, Symlinks symlinks, Cryptor cryptor) {
+	public CryptoUserDefinedFileAttributeView(CryptoPath cleartextPath, CryptoPathMapper pathMapper, LinkOption[] linkOptions, Symlinks symlinks, Cryptor cryptor) {
 		super(cleartextPath, pathMapper, linkOptions, symlinks);
 		this.cryptor = cryptor;
 	}
@@ -45,7 +45,8 @@ final class CryptoUserDefinedAttributeView extends AbstractCryptoFileAttributeVi
 	@Override
 	public int size(String cleartextName) throws IOException {
 		var ciphertextName = encryptName(cleartextName);
-		return getCiphertextAttributeView(UserDefinedFileAttributeView.class).size(ciphertextName);
+		var ciphertextSize = getCiphertextAttributeView(UserDefinedFileAttributeView.class).size(ciphertextName);
+		return (int) cryptor.fileContentCryptor().cleartextSize(ciphertextSize) - cryptor.fileHeaderCryptor().headerSize();
 	}
 
 	@Override

--- a/src/test/java/org/cryptomator/cryptofs/attr/CryptoFileOwnerAttributeViewTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/attr/CryptoFileOwnerAttributeViewTest.java
@@ -39,7 +39,6 @@ public class CryptoFileOwnerAttributeViewTest {
 	private CryptoPath cleartextPath = mock(CryptoPath.class);
 	private CryptoPathMapper pathMapper = mock(CryptoPathMapper.class);
 	private Symlinks symlinks = mock(Symlinks.class);
-	private OpenCryptoFiles openCryptoFiles = mock(OpenCryptoFiles.class);
 	private ReadonlyFlag readonlyFlag = mock(ReadonlyFlag.class);
 
 	private CryptoFileOwnerAttributeView inTest;
@@ -61,7 +60,7 @@ public class CryptoFileOwnerAttributeViewTest {
 		when(linkCiphertextPath.getSymlinkFilePath()).thenReturn(linkCiphertextRawPath);
 		when(ciphertextPath.getFilePath()).thenReturn(ciphertextRawPath);
 
-		inTest = new CryptoFileOwnerAttributeView(cleartextPath, pathMapper, new LinkOption[]{}, symlinks, openCryptoFiles, readonlyFlag);
+		inTest = new CryptoFileOwnerAttributeView(cleartextPath, pathMapper, new LinkOption[]{}, symlinks, readonlyFlag);
 	}
 
 	@Test
@@ -91,7 +90,7 @@ public class CryptoFileOwnerAttributeViewTest {
 	public void testSetOwnerOfSymlinkNoFollow() throws IOException {
 		UserPrincipal principal = mock(UserPrincipal.class);
 
-		CryptoFileOwnerAttributeView view = new CryptoFileOwnerAttributeView(link, pathMapper, new LinkOption[]{LinkOption.NOFOLLOW_LINKS}, symlinks, openCryptoFiles, readonlyFlag);
+		CryptoFileOwnerAttributeView view = new CryptoFileOwnerAttributeView(link, pathMapper, new LinkOption[]{LinkOption.NOFOLLOW_LINKS}, symlinks, readonlyFlag);
 		view.setOwner(principal);
 
 		verify(linkDelegate).setOwner(principal);
@@ -101,7 +100,7 @@ public class CryptoFileOwnerAttributeViewTest {
 	public void testSetOwnerOfSymlinkFollow() throws IOException {
 		UserPrincipal principal = mock(UserPrincipal.class);
 
-		CryptoFileOwnerAttributeView view = new CryptoFileOwnerAttributeView(link, pathMapper, new LinkOption[]{}, symlinks, openCryptoFiles, readonlyFlag);
+		CryptoFileOwnerAttributeView view = new CryptoFileOwnerAttributeView(link, pathMapper, new LinkOption[]{}, symlinks, readonlyFlag);
 		view.setOwner(principal);
 
 		verify(delegate).setOwner(principal);

--- a/src/test/java/org/cryptomator/cryptofs/attr/CryptoUserDefinedFileAttributeViewTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/attr/CryptoUserDefinedFileAttributeViewTest.java
@@ -1,0 +1,134 @@
+package org.cryptomator.cryptofs.attr;
+
+import org.cryptomator.cryptofs.CiphertextFilePath;
+import org.cryptomator.cryptofs.CryptoPath;
+import org.cryptomator.cryptofs.CryptoPathMapper;
+import org.cryptomator.cryptofs.Symlinks;
+import org.cryptomator.cryptofs.common.CiphertextFileType;
+import org.cryptomator.cryptolib.api.Cryptor;
+import org.cryptomator.cryptolib.api.FileContentCryptor;
+import org.cryptomator.cryptolib.api.FileHeader;
+import org.cryptomator.cryptolib.api.FileHeaderCryptor;
+import org.cryptomator.cryptolib.api.FileNameCryptor;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.attribute.UserDefinedFileAttributeView;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CryptoUserDefinedFileAttributeViewTest {
+
+	private final Cryptor cryptor = mock(Cryptor.class);
+	private final FileNameCryptor fileNameCryptor = mock(FileNameCryptor.class);
+	private final FileHeaderCryptor fileHeaderCryptor = mock(FileHeaderCryptor.class);
+	private final FileContentCryptor fileContentCryptor = mock(FileContentCryptor.class);
+	private final CiphertextFilePath ciphertextPath = mock(CiphertextFilePath.class);
+	private final Path ciphertextRawPath = mock(Path.class);
+	private final FileSystem fileSystem = mock(FileSystem.class);
+	private final FileSystemProvider provider = mock(FileSystemProvider.class);
+	private final UserDefinedFileAttributeView delegate = mock(UserDefinedFileAttributeView.class);
+	private final CryptoPath cleartextPath = mock(CryptoPath.class);
+	private final CryptoPathMapper pathMapper = mock(CryptoPathMapper.class);
+	private final Symlinks symlinks = mock(Symlinks.class);
+
+	private CryptoUserDefinedFileAttributeView inTest;
+
+	@BeforeEach
+	public void setUp() throws IOException {
+		when(cryptor.fileNameCryptor()).thenReturn(fileNameCryptor);
+		when(cryptor.fileHeaderCryptor()).thenReturn(fileHeaderCryptor);
+		when(cryptor.fileContentCryptor()).thenReturn(fileContentCryptor);
+		when(fileNameCryptor.encryptFilename(Mockito.any(), Mockito.any(), Mockito.any())).thenAnswer(invocation -> invocation.getArgument(1));
+		when(fileNameCryptor.decryptFilename(Mockito.any(), Mockito.any(), Mockito.any())).thenAnswer(invocation -> invocation.getArgument(1));
+		when(fileHeaderCryptor.headerSize()).thenReturn(4);
+		when(fileHeaderCryptor.decryptHeader(Mockito.any())).thenReturn(Mockito.mock(FileHeader.class));
+		when(fileHeaderCryptor.encryptHeader(Mockito.any())).thenReturn(StandardCharsets.UTF_8.encode("HEAD"));
+		when(fileContentCryptor.ciphertextChunkSize()).thenReturn(1024);
+		when(fileContentCryptor.cleartextChunkSize()).thenReturn(1024);
+		when(fileContentCryptor.cleartextSize(Mockito.anyLong())).thenCallRealMethod();
+		when(fileContentCryptor.decryptChunk(Mockito.any(), Mockito.anyLong(), Mockito.any(), Mockito.anyBoolean())).thenAnswer(invocation -> invocation.getArgument(0));
+		when(fileContentCryptor.encryptChunk(Mockito.any(), Mockito.anyLong(), Mockito.any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+		when(ciphertextRawPath.getFileSystem()).thenReturn(fileSystem);
+		when(fileSystem.provider()).thenReturn(provider);
+		when(provider.getFileAttributeView(ciphertextRawPath, UserDefinedFileAttributeView.class)).thenReturn(delegate);
+		when(pathMapper.getCiphertextFileType(cleartextPath)).thenReturn(CiphertextFileType.FILE);
+		when(pathMapper.getCiphertextFilePath(cleartextPath)).thenReturn(ciphertextPath);
+		when(ciphertextPath.getFilePath()).thenReturn(ciphertextRawPath);
+
+		inTest = new CryptoUserDefinedFileAttributeView(cleartextPath, pathMapper, new LinkOption[]{}, symlinks, cryptor);
+	}
+
+	@Test
+	public void testName() {
+		Assertions.assertEquals("user", inTest.name());
+	}
+
+	@Test
+	public void testList() throws IOException {
+		when(delegate.list()).thenReturn(Arrays.asList("c9r.Foo", "c9r.Bar"));
+		List<String> result = inTest.list();
+		MatcherAssert.assertThat(result, CoreMatchers.hasItems("Foo", "Bar"));
+	}
+
+	@Test
+	public void testSize() throws IOException {
+		when(delegate.size("c9r.Foo")).thenReturn(50);
+		int result = inTest.size("Foo");
+		Assertions.assertEquals(46, result);
+	}
+
+	@Test
+	public void testWrite() throws IOException {
+		when(delegate.write(Mockito.eq("c9r.Foo"), Mockito.any())).thenAnswer(invocation -> {
+			ByteBuffer buf = invocation.getArgument(1);
+			int len = buf.remaining();
+			buf.position(buf.position() + len);
+			return len;
+		});
+
+		int written = inTest.write("Foo", StandardCharsets.UTF_8.encode("Hello World"));
+		Assertions.assertEquals("Hello World".length(), written);
+		Mockito.verify(delegate).write(Mockito.eq("c9r.Foo"), Mockito.any());
+	}
+
+	@Test
+	public void testRead() throws IOException {
+		byte[] content = "HEADHello World".getBytes(StandardCharsets.UTF_8);
+		when(delegate.size("c9r.Foo")).thenReturn(content.length);
+		when(delegate.read(Mockito.eq("c9r.Foo"), Mockito.any())).thenAnswer(invocation -> {
+			ByteBuffer buf = invocation.getArgument(1);
+			buf.put(content);
+			return content.length;
+		});
+
+		ByteBuffer buf = ByteBuffer.allocate(inTest.size("Foo"));
+		int read = inTest.read("Foo", buf);
+		Assertions.assertEquals("Hello World".length(), read);
+		buf.flip();
+		Assertions.assertEquals("Hello World", StandardCharsets.UTF_8.decode(buf).toString());
+	}
+
+	@Test
+	public void testDelete() throws IOException {
+		inTest.delete("Foo");
+		Mockito.verify(delegate).delete(Mockito.eq("c9r.Foo"));
+
+	}
+
+}


### PR DESCRIPTION
Fixes #47

* Attribute names are `c9r.` + base64url-encoded siv-encrypted attribute names
* Attribute values are encrypted in the same way as file contents

There is no shortening. TBD: How to deal with too long attribute names?

This PR replaces the stale branch [feature/47-user-attr](https://github.com/cryptomator/cryptofs/tree/feature/47-user-attr).