### PR TITLE
Feature: Use dagger factories instead of builders

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemComponent.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemComponent.java
@@ -12,25 +12,13 @@ public interface CryptoFileSystemComponent {
 
 	CryptoFileSystemImpl cryptoFileSystem();
 
-	@Subcomponent.Builder
-	interface Builder {
-
-		@BindsInstance
-		Builder cryptor(Cryptor cryptor);
-
-		@BindsInstance
-		Builder vaultConfig(VaultConfig vaultConfig);
-
-		@BindsInstance
-		Builder provider(CryptoFileSystemProvider provider);
-
-		@BindsInstance
-		Builder pathToVault(@PathToVault Path pathToVault);
-
-		@BindsInstance
-		Builder properties(CryptoFileSystemProperties cryptoFileSystemProperties);
-
-		CryptoFileSystemComponent build();
+	@Subcomponent.Factory
+	interface Factory {
+		CryptoFileSystemComponent create(@BindsInstance Cryptor cryptor, //
+										 @BindsInstance VaultConfig vaultConfig, //
+										 @BindsInstance CryptoFileSystemProvider provider, //
+										 @BindsInstance @PathToVault Path pathToVault, //
+										 @BindsInstance CryptoFileSystemProperties cryptoFileSystemProperties);
 	}
 
 }

--- a/src/main/java/org/cryptomator/cryptofs/attr/AttributeComponent.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/AttributeComponent.java
@@ -24,18 +24,12 @@ public interface AttributeComponent {
 		}
 	}
 
-	@Subcomponent.Builder
-	interface Builder {
+	@Subcomponent.Factory
+	interface Factory {
 
-		@BindsInstance
-		Builder ciphertextPath(Path ciphertextPath);
+		AttributeComponent create(@BindsInstance Path ciphertextPath, //
+								  @BindsInstance CiphertextFileType ciphertextFileType, //
+								  @BindsInstance @Named("ciphertext") BasicFileAttributes ciphertextAttributes);
 
-		@BindsInstance
-		Builder ciphertextFileType(CiphertextFileType ciphertextFileType);
-
-		@BindsInstance
-		Builder ciphertextAttributes(@Named("ciphertext") BasicFileAttributes ciphertextAttributes);
-
-		AttributeComponent build();
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/attr/AttributeProvider.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/AttributeProvider.java
@@ -16,7 +16,6 @@ import org.cryptomator.cryptofs.common.ArrayUtils;
 import org.cryptomator.cryptofs.common.CiphertextFileType;
 
 import javax.inject.Inject;
-import javax.inject.Provider;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
@@ -26,13 +25,13 @@ import java.nio.file.attribute.BasicFileAttributes;
 @CryptoFileSystemScoped
 public class AttributeProvider {
 
-	private final Provider<AttributeComponent.Builder> attributeComponentBuilderProvider;
+	private final AttributeComponent.Factory attributeComponentFactory;
 	private final CryptoPathMapper pathMapper;
 	private final Symlinks symlinks;
 
 	@Inject
-	AttributeProvider(Provider<AttributeComponent.Builder> attributeComponentBuilderProvider, CryptoPathMapper pathMapper, Symlinks symlinks) {
-		this.attributeComponentBuilderProvider = attributeComponentBuilderProvider;
+	AttributeProvider(AttributeComponent.Factory attributeComponentFactory, CryptoPathMapper pathMapper, Symlinks symlinks) {
+		this.attributeComponentFactory = attributeComponentFactory;
 		this.pathMapper = pathMapper;
 		this.symlinks = symlinks;
 	}
@@ -45,13 +44,10 @@ public class AttributeProvider {
 		}
 		Path ciphertextPath = getCiphertextPath(cleartextPath, ciphertextFileType);
 		A ciphertextAttrs = Files.readAttributes(ciphertextPath, type);
-		AttributeComponent.Builder builder = attributeComponentBuilderProvider.get();
-		return builder  //
-				.ciphertextFileType(ciphertextFileType) //
-				.ciphertextPath(ciphertextPath) //
-				.ciphertextAttributes(ciphertextAttrs) //
-				.build() //
-				.attributes(type);
+		return attributeComponentFactory.create(ciphertextPath, //
+						ciphertextFileType, //
+						ciphertextAttrs) //
+				.attributes(type); //
 	}
 
 	private Path getCiphertextPath(CryptoPath path, CiphertextFileType type) throws IOException {

--- a/src/main/java/org/cryptomator/cryptofs/attr/AttributeViewComponent.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/AttributeViewComponent.java
@@ -14,19 +14,11 @@ public interface AttributeViewComponent {
 
 	Optional<FileAttributeView> attributeView();
 
-	@Subcomponent.Builder
-	interface Builder {
+	@Subcomponent.Factory
+	interface Factory {
 
-		@BindsInstance
-		Builder cleartextPath(CryptoPath cleartextPath);
+		AttributeViewComponent create(@BindsInstance CryptoPath cleartextPath, @BindsInstance Class<? extends FileAttributeView> type, @BindsInstance LinkOption[] linkOptions);
 
-		@BindsInstance
-		Builder viewType(Class<? extends FileAttributeView> type);
-
-		@BindsInstance
-		Builder linkOptions(LinkOption[] linkOptions);
-
-		AttributeViewComponent build();
 	}
 
 }

--- a/src/main/java/org/cryptomator/cryptofs/attr/AttributeViewProvider.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/AttributeViewProvider.java
@@ -14,7 +14,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import javax.inject.Provider;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.attribute.FileAttributeView;
@@ -25,27 +24,21 @@ public class AttributeViewProvider {
 
 	private static final Logger LOG = LoggerFactory.getLogger(AttributeViewProvider.class);
 
-	private final Provider<AttributeViewComponent.Builder> attrViewComponentBuilderProvider;
+	private final AttributeViewComponent.Factory attrViewComponentFactory;
 
 	@Inject
-	AttributeViewProvider(Provider<AttributeViewComponent.Builder> attrViewComponentBuilderProvider) {
-		this.attrViewComponentBuilderProvider = attrViewComponentBuilderProvider;
+	AttributeViewProvider(AttributeViewComponent.Factory attrViewComponentFactory) {
+		this.attrViewComponentFactory = attrViewComponentFactory;
 	}
 
 	/**
 	 * @param cleartextPath the unencrypted path to the file
-	 * @param type          the Class object corresponding to the file attribute view
+	 * @param type the Class object corresponding to the file attribute view
 	 * @return a file attribute view of the specified type, or <code>null</code> if the attribute view type is not available
 	 * @see Files#getFileAttributeView(java.nio.file.Path, Class, java.nio.file.LinkOption...)
 	 */
 	public <A extends FileAttributeView> A getAttributeView(CryptoPath cleartextPath, Class<A> type, LinkOption... options) {
-		AttributeViewComponent.Builder builder = attrViewComponentBuilderProvider.get();
-		Optional<FileAttributeView> view = builder //
-				.cleartextPath(cleartextPath) //
-				.viewType(type) //
-				.linkOptions(options) //
-				.build() //
-				.attributeView();
+		Optional<FileAttributeView> view = attrViewComponentFactory.create(cleartextPath, type, options).attributeView();
 		if (view.isPresent() && type.isInstance(view.get())) {
 			return type.cast(view.get());
 		} else {

--- a/src/main/java/org/cryptomator/cryptofs/ch/ChannelComponent.java
+++ b/src/main/java/org/cryptomator/cryptofs/ch/ChannelComponent.java
@@ -13,25 +13,14 @@ public interface ChannelComponent {
 
 	CleartextFileChannel channel();
 
-	@Subcomponent.Builder
-	interface Builder {
+	@Subcomponent.Factory
+	interface Factory {
 
-		@BindsInstance
-		Builder openOptions(EffectiveOpenOptions options);
-
-		@BindsInstance
-		Builder onClose(ChannelCloseListener listener);
-
-		@BindsInstance
-		Builder ciphertextChannel(FileChannel ciphertextChannel);
-
-		@BindsInstance
-		Builder mustWriteHeader(@MustWriteHeader boolean mustWriteHeader);
-
-		@BindsInstance
-		Builder fileHeader(FileHeader fileHeader);
-
-		ChannelComponent build();
+		ChannelComponent create(@BindsInstance FileChannel ciphertextChannel, //
+								@BindsInstance FileHeader fileHeader, //
+								@BindsInstance @MustWriteHeader boolean mustWriteHeader, //
+								@BindsInstance EffectiveOpenOptions options, //
+								@BindsInstance ChannelCloseListener listener); //
 	}
 
 }

--- a/src/main/java/org/cryptomator/cryptofs/dir/DirectoryStreamComponent.java
+++ b/src/main/java/org/cryptomator/cryptofs/dir/DirectoryStreamComponent.java
@@ -14,25 +14,14 @@ public interface DirectoryStreamComponent {
 
 	CryptoDirectoryStream directoryStream();
 
-	@Subcomponent.Builder
-	interface Builder {
+	@Subcomponent.Factory
+	interface Factory {
 
-		@BindsInstance
-		Builder cleartextPath(@Named("cleartextPath") Path cleartextPath);
-
-		@BindsInstance
-		Builder dirId(@Named("dirId") String dirId);
-
-		@BindsInstance
-		Builder ciphertextDirectoryStream(DirectoryStream<Path> ciphertextDirectoryStream);
-
-		@BindsInstance
-		Builder filter(DirectoryStream.Filter<? super Path> filter);
-
-		@BindsInstance
-		Builder onClose(Consumer<CryptoDirectoryStream> onClose);
-
-		DirectoryStreamComponent build();
+		DirectoryStreamComponent create(@BindsInstance @Named("cleartextPath") Path cleartextPath, //
+										@BindsInstance @Named("dirId") String dirId, //
+										@BindsInstance DirectoryStream<Path> ciphertextDirectoryStream, //
+										@BindsInstance DirectoryStream.Filter<? super Path> filter, //
+										@BindsInstance Consumer<CryptoDirectoryStream> onClose);
 	}
 
 }

--- a/src/main/java/org/cryptomator/cryptofs/fh/OpenCryptoFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/OpenCryptoFile.java
@@ -9,7 +9,6 @@
 package org.cryptomator.cryptofs.fh;
 
 import org.cryptomator.cryptofs.EffectiveOpenOptions;
-import org.cryptomator.cryptofs.ch.ChannelComponent;
 import org.cryptomator.cryptofs.ch.CleartextFileChannel;
 import org.cryptomator.cryptolib.api.Cryptor;
 import org.cryptomator.cryptolib.api.FileHeader;
@@ -87,14 +86,9 @@ public class OpenCryptoFile implements Closeable {
 				isNewHeader = false;
 			}
 			initFileSize(ciphertextFileChannel);
-			ChannelComponent channelComponent = component.newChannelComponent() //
-					.ciphertextChannel(ciphertextFileChannel) //
-					.openOptions(options) //
-					.onClose(this::channelClosed) //
-					.mustWriteHeader(isNewHeader) //
-					.fileHeader(header) //
-					.build();
-			cleartextFileChannel = channelComponent.channel();
+			cleartextFileChannel = component.newChannelComponent() //
+					.create(ciphertextFileChannel, header, isNewHeader, options, this::channelClosed) //
+					.channel();
 		} finally {
 			if (cleartextFileChannel == null) { // i.e. something didn't work
 				closeQuietly(ciphertextFileChannel);

--- a/src/main/java/org/cryptomator/cryptofs/fh/OpenCryptoFileComponent.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/OpenCryptoFileComponent.java
@@ -12,7 +12,7 @@ public interface OpenCryptoFileComponent {
 
 	OpenCryptoFile openCryptoFile();
 
-	ChannelComponent.Builder newChannelComponent();
+	ChannelComponent.Factory newChannelComponent();
 
 	@Subcomponent.Builder
 	interface Builder {

--- a/src/main/java/org/cryptomator/cryptofs/fh/OpenCryptoFileComponent.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/OpenCryptoFileComponent.java
@@ -14,16 +14,11 @@ public interface OpenCryptoFileComponent {
 
 	ChannelComponent.Factory newChannelComponent();
 
-	@Subcomponent.Builder
-	interface Builder {
+	@Subcomponent.Factory
+	interface Factory {
 
-		@BindsInstance
-		Builder path(@OriginalOpenFilePath Path path);
-
-		@BindsInstance
-		Builder onClose(FileCloseListener listener);
-
-		OpenCryptoFileComponent build();
+		OpenCryptoFileComponent create(@BindsInstance @OriginalOpenFilePath Path path, //
+									   @BindsInstance FileCloseListener onCloseListener);
 	}
 
 }

--- a/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemsTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemsTest.java
@@ -57,7 +57,7 @@ public class CryptoFileSystemsTest {
 	private final CryptorProvider cryptorProvider = mock(CryptorProvider.class);
 	private final Cryptor cryptor = mock(Cryptor.class);
 	private final FileNameCryptor fileNameCryptor = mock(FileNameCryptor.class);
-	private final CryptoFileSystemComponent.Builder cryptoFileSystemComponentBuilder = mock(CryptoFileSystemComponent.Builder.class);
+	private final CryptoFileSystemComponent.Factory cryptoFileSystemComponentFactory = mock(CryptoFileSystemComponent.Factory.class);
 
 
 	private MockedStatic<VaultConfig> vaultConficClass;
@@ -65,7 +65,7 @@ public class CryptoFileSystemsTest {
 	private MockedStatic<CryptorProvider> cryptorProviderClass;
 	private MockedStatic<BackupHelper> backupHelperClass;
 
-	private final CryptoFileSystems inTest = new CryptoFileSystems(cryptoFileSystemComponentBuilder, capabilityChecker, csprng);
+	private final CryptoFileSystems inTest = new CryptoFileSystems(cryptoFileSystemComponentFactory, capabilityChecker, csprng);
 
 	@BeforeEach
 	public void setup() throws IOException, MasterkeyLoadingFailedException {
@@ -96,12 +96,7 @@ public class CryptoFileSystemsTest {
 		when(dataDirPath.resolve("AB")).thenReturn(preContenRootPath);
 		when(preContenRootPath.resolve("CDEFGHIJKLMNOP")).thenReturn(contenRootPath);
 		filesClass.when(() -> Files.exists(contenRootPath)).thenReturn(true);
-		when(cryptoFileSystemComponentBuilder.cryptor(any())).thenReturn(cryptoFileSystemComponentBuilder);
-		when(cryptoFileSystemComponentBuilder.vaultConfig(any())).thenReturn(cryptoFileSystemComponentBuilder);
-		when(cryptoFileSystemComponentBuilder.pathToVault(any())).thenReturn(cryptoFileSystemComponentBuilder);
-		when(cryptoFileSystemComponentBuilder.properties(any())).thenReturn(cryptoFileSystemComponentBuilder);
-		when(cryptoFileSystemComponentBuilder.provider(any())).thenReturn(cryptoFileSystemComponentBuilder);
-		when(cryptoFileSystemComponentBuilder.build()).thenReturn(cryptoFileSystemComponent);
+		when(cryptoFileSystemComponentFactory.create(any(),any(),any(),any(),any())).thenReturn(cryptoFileSystemComponent);
 		when(cryptoFileSystemComponent.cryptoFileSystem()).thenReturn(cryptoFileSystem);
 	}
 
@@ -124,12 +119,7 @@ public class CryptoFileSystemsTest {
 
 		Assertions.assertSame(cryptoFileSystem, impl);
 		Assertions.assertTrue(inTest.contains(cryptoFileSystem));
-		verify(cryptoFileSystemComponentBuilder).cryptor(cryptor);
-		verify(cryptoFileSystemComponentBuilder).vaultConfig(vaultConfig);
-		verify(cryptoFileSystemComponentBuilder).pathToVault(normalizedPathToVault);
-		verify(cryptoFileSystemComponentBuilder).properties(properties);
-		verify(cryptoFileSystemComponentBuilder).provider(provider);
-		verify(cryptoFileSystemComponentBuilder).build();
+		verify(cryptoFileSystemComponentFactory,Mockito.times(1)).create(cryptor, vaultConfig, provider, normalizedPathToVault, properties);
 	}
 
 	@Test

--- a/src/test/java/org/cryptomator/cryptofs/dir/DirectoryStreamFactoryTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/dir/DirectoryStreamFactoryTest.java
@@ -34,20 +34,15 @@ public class DirectoryStreamFactoryTest {
 	private final FileSystemProvider provider = mock(FileSystemProvider.class, "provider");
 	private final CryptoPathMapper cryptoPathMapper = mock(CryptoPathMapper.class);
 	private final DirectoryStreamComponent directoryStreamComp = mock(DirectoryStreamComponent.class);
-	private final DirectoryStreamComponent.Builder directoryStreamBuilder = mock(DirectoryStreamComponent.Builder.class);
+	private final DirectoryStreamComponent.Factory directoryStreamFactory = mock(DirectoryStreamComponent.Factory.class);
 
-	private final DirectoryStreamFactory inTest = new DirectoryStreamFactory(cryptoPathMapper, directoryStreamBuilder);
+	private final DirectoryStreamFactory inTest = new DirectoryStreamFactory(cryptoPathMapper, directoryStreamFactory);
 
 	@SuppressWarnings("unchecked")
 
 	@BeforeEach
 	public void setup() throws IOException {
-		when(directoryStreamBuilder.cleartextPath(Mockito.any())).thenReturn(directoryStreamBuilder);
-		when(directoryStreamBuilder.dirId(Mockito.any())).thenReturn(directoryStreamBuilder);
-		when(directoryStreamBuilder.ciphertextDirectoryStream(Mockito.any())).thenReturn(directoryStreamBuilder);
-		when(directoryStreamBuilder.filter(Mockito.any())).thenReturn(directoryStreamBuilder);
-		when(directoryStreamBuilder.onClose(Mockito.any())).thenReturn(directoryStreamBuilder);
-		when(directoryStreamBuilder.build()).thenReturn(directoryStreamComp);
+		when(directoryStreamFactory.create(any(),any(),any(),any(),any())).thenReturn(directoryStreamComp);
 		when(directoryStreamComp.directoryStream()).then(invocation -> mock(CryptoDirectoryStream.class));
 		when(fileSystem.provider()).thenReturn(provider);
 	}

--- a/src/test/java/org/cryptomator/cryptofs/fh/OpenCryptoFilesTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/fh/OpenCryptoFilesTest.java
@@ -16,12 +16,12 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 
 public class OpenCryptoFilesTest {
 
-	private final Provider<OpenCryptoFileComponent.Builder> openCryptoFileComponentBuilderProvider = mock(Provider.class);
-	private final OpenCryptoFileComponent.Builder openCryptoFileComponentBuilder = mock(OpenCryptoFileComponent.Builder.class);
+	private final OpenCryptoFileComponent.Factory openCryptoFileComponentFactory = mock(OpenCryptoFileComponent.Factory.class);
 	private final OpenCryptoFile file = mock(OpenCryptoFile.class, "file");
 	private final FileChannel ciphertextFileChannel = Mockito.mock(FileChannel.class);
 
@@ -32,14 +32,10 @@ public class OpenCryptoFilesTest {
 		OpenCryptoFileComponent subComponent = mock(OpenCryptoFileComponent.class);
 		Mockito.when(subComponent.openCryptoFile()).thenReturn(file);
 
-		Mockito.when(openCryptoFileComponentBuilderProvider.get()).thenReturn(openCryptoFileComponentBuilder);
-		Mockito.when(openCryptoFileComponentBuilder.path(Mockito.any())).thenReturn(openCryptoFileComponentBuilder);
-		Mockito.when(openCryptoFileComponentBuilder.onClose(Mockito.any())).thenReturn(openCryptoFileComponentBuilder);
-		Mockito.when(openCryptoFileComponentBuilder.build()).thenReturn(subComponent);
-
+		Mockito.when(openCryptoFileComponentFactory.create(Mockito.any(), Mockito.any())).thenReturn(subComponent);
 		Mockito.when(file.newFileChannel(Mockito.any())).thenReturn(ciphertextFileChannel);
 
-		inTest = new OpenCryptoFiles(openCryptoFileComponentBuilderProvider);
+		inTest = new OpenCryptoFiles(openCryptoFileComponentFactory);
 	}
 
 	@Test
@@ -52,7 +48,7 @@ public class OpenCryptoFilesTest {
 		OpenCryptoFile file2 = mock(OpenCryptoFile.class);
 		Mockito.when(subComponent2.openCryptoFile()).thenReturn(file2);
 
-		Mockito.when(openCryptoFileComponentBuilder.build()).thenReturn(subComponent1, subComponent2);
+		Mockito.when(openCryptoFileComponentFactory.create(Mockito.any(), Mockito.any())).thenReturn(subComponent1, subComponent2);
 
 		Path p1 = Paths.get("/foo");
 		Path p2 = Paths.get("/bar");
@@ -140,24 +136,18 @@ public class OpenCryptoFilesTest {
 		Path path1 = Mockito.mock(Path.class, "/file1");
 		Mockito.when(path1.toAbsolutePath()).thenReturn(path1);
 		Mockito.when(path1.normalize()).thenReturn(path1);
-		OpenCryptoFileComponent.Builder subComponentBuilder1 = mock(OpenCryptoFileComponent.Builder.class);
 		OpenCryptoFileComponent subComponent1 = mock(OpenCryptoFileComponent.class);
 		OpenCryptoFile file1 = mock(OpenCryptoFile.class, "file1");
-		Mockito.when(openCryptoFileComponentBuilder.path(path1)).thenReturn(subComponentBuilder1);
-		Mockito.when(subComponentBuilder1.onClose(Mockito.any())).thenReturn(subComponentBuilder1);
-		Mockito.when(subComponentBuilder1.build()).thenReturn(subComponent1);
+		Mockito.when(openCryptoFileComponentFactory.create(Mockito.eq(path1), Mockito.any())).thenReturn(subComponent1);
 		Mockito.when(subComponent1.openCryptoFile()).thenReturn(file1);
 		Mockito.when(file1.getCurrentFilePath()).thenReturn(path1);
 
 		Path path2 = Mockito.mock(Path.class, "/file2");
 		Mockito.when(path2.toAbsolutePath()).thenReturn(path2);
 		Mockito.when(path2.normalize()).thenReturn(path2);
-		OpenCryptoFileComponent.Builder subComponentBuilder2 = mock(OpenCryptoFileComponent.Builder.class);
 		OpenCryptoFileComponent subComponent2 = mock(OpenCryptoFileComponent.class);
 		OpenCryptoFile file2 = mock(OpenCryptoFile.class, "file2");
-		Mockito.when(openCryptoFileComponentBuilder.path(path2)).thenReturn(subComponentBuilder2);
-		Mockito.when(subComponentBuilder2.onClose(Mockito.any())).thenReturn(subComponentBuilder2);
-		Mockito.when(subComponentBuilder2.build()).thenReturn(subComponent2);
+		Mockito.when(openCryptoFileComponentFactory.create(Mockito.eq(path2), Mockito.any())).thenReturn(subComponent2);
 		Mockito.when(subComponent2.openCryptoFile()).thenReturn(file2);
 		Mockito.when(file2.getCurrentFilePath()).thenReturn(path2);
 

--- a/src/test/java/org/cryptomator/cryptofs/fh/OpenCryptoFilesTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/fh/OpenCryptoFilesTest.java
@@ -16,7 +16,6 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 
 public class OpenCryptoFilesTest {


### PR DESCRIPTION
This PR replaces all dagger `@Subcomponent.Builder`s with dagger [Factories](https://dagger.dev/api/latest/dagger/Component.Factory.html).

Factories guarentee to always return a new instance and do not have a public state, hence they are threadsafe.