### PR TITLE
Feature: Remove deleted file from openFiles map and set file path to null

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemImpl.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemImpl.java
@@ -421,8 +421,13 @@ class CryptoFileSystemImpl extends CryptoFileSystem {
 		CiphertextFilePath ciphertextPath = cryptoPathMapper.getCiphertextFilePath(cleartextPath);
 		switch (ciphertextFileType) {
 			case DIRECTORY -> deleteDirectory(cleartextPath, ciphertextPath);
-			case FILE, SYMLINK -> Files.walkFileTree(ciphertextPath.getRawPath(), DeletingFileVisitor.INSTANCE);
+			case FILE, SYMLINK -> deleteFileOrSymlink(ciphertextPath);
 		}
+	}
+
+	private void deleteFileOrSymlink(CiphertextFilePath ciphertextPath) throws IOException {
+		openCryptoFiles.delete(ciphertextPath.getFilePath());
+		Files.walkFileTree(ciphertextPath.getRawPath(), DeletingFileVisitor.INSTANCE);
 	}
 
 	private void deleteDirectory(CryptoPath cleartextPath, CiphertextFilePath ciphertextPath) throws IOException {

--- a/src/main/java/org/cryptomator/cryptofs/fh/OpenCryptoFileModule.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/OpenCryptoFileModule.java
@@ -28,18 +28,9 @@ public class OpenCryptoFileModule {
 
 	@Provides
 	@OpenFileScoped
-	@CurrentOpenFilePath // TODO: do we still need this? only used in logging.
+	@CurrentOpenFilePath
 	public AtomicReference<Path> provideCurrentPath(@OriginalOpenFilePath Path originalPath) {
 		return new AtomicReference<>(originalPath);
-	}
-
-	@Provides
-	@OpenFileScoped
-	public Supplier<BasicFileAttributeView> provideBasicFileAttributeViewSupplier(@CurrentOpenFilePath AtomicReference<Path> currentPath) {
-		return () -> {
-			Path path = currentPath.get();
-			return path.getFileSystem().provider().getFileAttributeView(path, BasicFileAttributeView.class);
-		};
 	}
 
 	@Provides

--- a/src/main/java/org/cryptomator/cryptofs/fh/OpenCryptoFiles.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/OpenCryptoFiles.java
@@ -82,6 +82,20 @@ public class OpenCryptoFiles implements Closeable {
 	}
 
 	/**
+	 * Removes a ciphertextPath to {@link OpenCryptoFile} mapping, if it exists, and sets the path of the openCryptoFile to null.
+	 *
+	 * @param ciphertextPath The ciphertext file path to invalidate
+	 */
+	public void delete(Path ciphertextPath) {
+		openCryptoFiles.compute(ciphertextPath, (p, openFile) -> {
+			if (openFile != null) {
+				openFile.updateCurrentFilePath(null);
+			}
+			return null;
+		});
+	}
+
+	/**
 	 * Prepares to update any open file references during a move operation.
 	 * MUST be invoked using a try-with-resource statement and committed after the physical file move succeeded.
 	 *
@@ -137,7 +151,7 @@ public class OpenCryptoFiles implements Closeable {
 				throw new IllegalStateException();
 			}
 			if (openCryptoFile != null) {
-				openCryptoFile.setCurrentFilePath(dst);
+				openCryptoFile.updateCurrentFilePath(dst);
 			}
 			openCryptoFiles.remove(src, openCryptoFile);
 			committed = true;

--- a/src/test/java/org/cryptomator/cryptofs/CryptoFileChannelWriteReadIntegrationTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/CryptoFileChannelWriteReadIntegrationTest.java
@@ -561,7 +561,7 @@ public class CryptoFileChannelWriteReadIntegrationTest {
 		//https://github.com/cryptomator/cryptofs/issues/170
 		@Test
 		public void testWriteThenDeleteThenRead() throws IOException {
-			var bufToWrite = ByteBuffer.wrap("delete me".getBytes(StandardCharsets.UTF_8));
+			var bufToWrite = StandardCharsets.UTF_8.encode("delete me");
 			final int bytesRead;
 			try (var ch = FileChannel.open(file, CREATE_NEW, WRITE)) {
 				ch.write(bufToWrite);

--- a/src/test/java/org/cryptomator/cryptofs/CryptoFileChannelWriteReadIntegrationTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/CryptoFileChannelWriteReadIntegrationTest.java
@@ -48,6 +48,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
@@ -555,6 +556,21 @@ public class CryptoFileChannelWriteReadIntegrationTest {
 				}
 			});
 			Assertions.assertTrue(Files.notExists(file));
+		}
+
+		//https://github.com/cryptomator/cryptofs/issues/170
+		@Test
+		public void testWriteThenDeleteThenRead() throws IOException {
+			var bufToWrite = ByteBuffer.wrap("delete me".getBytes(StandardCharsets.UTF_8));
+			final int bytesRead;
+			try (var ch = FileChannel.open(file, CREATE_NEW, WRITE)) {
+				ch.write(bufToWrite);
+				Files.delete(file);
+				try (var ch2 = fileSystem.provider().newFileChannel(file, Set.of(CREATE, READ, WRITE))) {
+					bytesRead = ch2.read(ByteBuffer.allocate(bufToWrite.capacity()));
+				}
+			}
+			Assertions.assertEquals(-1, bytesRead);
 		}
 	}
 

--- a/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemImplTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemImplTest.java
@@ -72,6 +72,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -558,6 +559,7 @@ public class CryptoFileSystemImplTest {
 		private final CryptoPath cleartextPath = mock(CryptoPath.class, "cleartext");
 		private final Path ciphertextRawPath = mock(Path.class, "d/00/00/path.c9r");
 		private final Path ciphertextDirFilePath = mock(Path.class, "d/00/00/path.c9r/dir.c9r");
+		private final Path ciphertextFilePath = mock(Path.class, "d/00/00/path.c9r");
 		private final Path ciphertextDirPath = mock(Path.class, "d/FF/FF/");
 		private final CiphertextFilePath ciphertextPath = mock(CiphertextFilePath.class, "ciphertext");
 		private final FileSystem physicalFs = mock(FileSystem.class);
@@ -574,6 +576,7 @@ public class CryptoFileSystemImplTest {
 			when(ciphertextRawPath.resolve("dir.c9r")).thenReturn(ciphertextDirFilePath);
 			when(cryptoPathMapper.getCiphertextFilePath(cleartextPath)).thenReturn(ciphertextPath);
 			when(ciphertextPath.getRawPath()).thenReturn(ciphertextRawPath);
+			when(ciphertextPath.getFilePath()).thenReturn(ciphertextFilePath);
 			when(ciphertextPath.getDirFilePath()).thenReturn(ciphertextDirFilePath);
 			when(cryptoPathMapper.getCiphertextDir(cleartextPath)).thenReturn(new CiphertextDirectory("foo", ciphertextDirPath));
 			when(physicalFsProv.readAttributes(ciphertextRawPath, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS)).thenReturn(ciphertextPathAttr);
@@ -590,10 +593,12 @@ public class CryptoFileSystemImplTest {
 		public void testDeleteExistingFile() throws IOException {
 			when(cryptoPathMapper.getCiphertextFileType(cleartextPath)).thenReturn(CiphertextFileType.FILE);
 			when(physicalFsProv.deleteIfExists(ciphertextRawPath)).thenReturn(true);
+			doNothing().when(openCryptoFiles).delete(Mockito.any());
 
 			inTest.delete(cleartextPath);
 
 			verify(readonlyFlag).assertWritable();
+			verify(openCryptoFiles).delete(ciphertextFilePath);
 			verify(physicalFsProv).deleteIfExists(ciphertextRawPath);
 		}
 


### PR DESCRIPTION
Fixes #170.

Before actually deleting files on the underlying file system, the openCryptoFile is removed from the (path, file)-mapping. Additionally, the `currentFilePath` object is null'ed, to indicate the openCryptoFile should not be used anymore. The usages of `currentFilePath` are updated to be null safe.


Note, that this only fixes a "symptom", there is still surface for bad timing. The root cause is described in #171.