### PR TITLE
Use Chunk.data() directly when putting chunk

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/fh/ChunkCache.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/ChunkCache.java
@@ -86,9 +86,10 @@ public class ChunkCache {
 				if (chunk == null) {
 					chunk = new Chunk(chunkData, true, () -> releaseChunk(chunkIndex));
 				} else {
-					var dst = chunk.data().duplicate().clear();
+					var dst = chunk.data().clear();
 					Preconditions.checkArgument(chunkData.remaining() == dst.remaining());
-					dst.put(chunkData);
+					dst.put(chunkData) //
+							.flip();
 					chunk.dirty().set(true);
 				}
 				chunk.currentAccesses().incrementAndGet();


### PR DESCRIPTION
Fixes #173

The chunk data is directly modified. This might lead to data corruption when writing unsynchronized to the same file from different file channels, but the library consumer must handle synchronization.