### PR TITLE
Feature: Do not recursively update cache

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/CryptoPathMapper.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoPathMapper.java
@@ -20,7 +20,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
@@ -124,7 +123,7 @@ public class CryptoPathMapper {
 		String cleartextName = cleartextPath.getFileName().toString();
 		return getCiphertextFilePath(parent.path, parent.dirId, cleartextName);
 	}
-	
+
 	public CiphertextFilePath getCiphertextFilePath(Path parentCiphertextDir, String parentDirId, String cleartextName) {
 		String ciphertextName = ciphertextNames.get(new DirIdAndName(parentDirId, cleartextName));
 		Path c9rPath = parentCiphertextDir.resolve(ciphertextName);
@@ -157,19 +156,15 @@ public class CryptoPathMapper {
 		if (parentPath == null) {
 			return rootDirectory;
 		} else {
-			try {
-				var lazyEntry = new CompletableFuture<CiphertextDirectory>();
-				var priorEntry = ciphertextDirectories.asMap().putIfAbsent(cleartextPath, lazyEntry);
-				if (priorEntry != null) {
-					return priorEntry.join();
-				} else {
-					Path dirFile = getCiphertextFilePath(cleartextPath).getDirFilePath();
-					CiphertextDirectory cipherDir = resolveDirectory(dirFile);
-					lazyEntry.complete(cipherDir);
-					return cipherDir;
-				}
-			} catch (UncheckedIOException e) {
-				throw new IOException(e);
+			var lazyEntry = new CompletableFuture<CiphertextDirectory>();
+			var priorEntry = ciphertextDirectories.asMap().putIfAbsent(cleartextPath, lazyEntry);
+			if (priorEntry != null) {
+				return priorEntry.join();
+			} else {
+				Path dirFile = getCiphertextFilePath(cleartextPath).getDirFilePath();
+				CiphertextDirectory cipherDir = resolveDirectory(dirFile);
+				lazyEntry.complete(cipherDir);
+				return cipherDir;
 			}
 		}
 	}

--- a/src/main/java/org/cryptomator/cryptofs/CryptoPathMapper.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoPathMapper.java
@@ -141,15 +141,13 @@ public class CryptoPathMapper {
 	}
 
 	public void invalidatePathMapping(CryptoPath cleartextPath) {
-		ciphertextDirectories.synchronous().invalidate(cleartextPath);
+		ciphertextDirectories.asMap().remove(cleartextPath);
 	}
 
 	public void movePathMapping(CryptoPath cleartextSrc, CryptoPath cleartextDst) {
-		var syncedCache = ciphertextDirectories.synchronous();
-		CiphertextDirectory cachedValue = syncedCache.getIfPresent(cleartextSrc);
+		var cachedValue = ciphertextDirectories.asMap().remove(cleartextSrc);
 		if (cachedValue != null) {
-			syncedCache.put(cleartextDst, cachedValue);
-			syncedCache.invalidate(cleartextSrc);
+			ciphertextDirectories.put(cleartextDst, cachedValue);
 		}
 	}
 

--- a/src/test/java/org/cryptomator/cryptofs/CryptoPathMapperTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/CryptoPathMapperTest.java
@@ -143,7 +143,7 @@ public class CryptoPathMapperTest {
 		Mockito.when(dataRoot.resolve("00")).thenReturn(d00);
 		Mockito.when(fileNameCryptor.hashDirectoryId("")).thenReturn("0000");
 
-		int maxNestingDepth = 9;
+		int maxNestingDepth = 97;
 
 		for (int depth=0; depth < maxNestingDepth; depth++) {
 			var dirId = "%02d".formatted(depth);

--- a/src/test/java/org/cryptomator/cryptofs/CryptoPathMapperTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/CryptoPathMapperTest.java
@@ -90,7 +90,7 @@ public class CryptoPathMapperTest {
 		Mockito.when(d00.resolve("00")).thenReturn(d0000);
 		Mockito.when(d0000.resolve("oof.c9r")).thenReturn(d0000oof);
 		Mockito.when(d0000oof.resolve("dir.c9r")).thenReturn(d0000oofdir);
-		Mockito.when(fileNameCryptor.encryptFilename(Mockito.any(),Mockito.eq("foo"), Mockito.any())).thenReturn("oof");
+		Mockito.when(fileNameCryptor.encryptFilename(Mockito.any(), Mockito.eq("foo"), Mockito.any())).thenReturn("oof");
 		Mockito.when(dirIdProvider.load(d0000oofdir)).thenReturn("1");
 		Mockito.when(fileNameCryptor.hashDirectoryId("1")).thenReturn("0001");
 
@@ -145,29 +145,29 @@ public class CryptoPathMapperTest {
 
 		int maxNestingDepth = 97;
 
-		for (int depth=0; depth < maxNestingDepth; depth++) {
+		for (int depth = 0; depth < maxNestingDepth; depth++) {
 			var dirId = "%02d".formatted(depth);
-			var nextDirId = "%02d".formatted(depth+1);
-			String pathPrefix = "d/00/"+dirId;
+			var nextDirId = "%02d".formatted(depth + 1);
+			String pathPrefix = "d/00/" + dirId;
 			Path contentDir = Mockito.mock(Path.class, pathPrefix);
-			Path dirLinkDir = Mockito.mock(Path.class, pathPrefix+"/cipherDir"+dirId+".c9r");
-			Path dirLinkFile = Mockito.mock(Path.class, pathPrefix + "/cipherDir"+dirId+".c9r/dir.c9r");
+			Path dirLinkDir = Mockito.mock(Path.class, pathPrefix + "/cipherDir" + dirId + ".c9r");
+			Path dirLinkFile = Mockito.mock(Path.class, pathPrefix + "/cipherDir" + dirId + ".c9r/dir.c9r");
 			Mockito.when(d00.resolve(dirId)).thenReturn(contentDir);
-			Mockito.when(contentDir.resolve("cipherDir"+dirId+".c9r")).thenReturn(dirLinkDir);
+			Mockito.when(contentDir.resolve("cipherDir" + dirId + ".c9r")).thenReturn(dirLinkDir);
 			Mockito.when(dirLinkDir.resolve("dir.c9r")).thenReturn(dirLinkFile);
-			Mockito.when(fileNameCryptor.encryptFilename(Mockito.any(), Mockito.eq(dirId), Mockito.any())).thenReturn("cipherDir"+dirId);
+			Mockito.when(fileNameCryptor.encryptFilename(Mockito.any(), Mockito.eq(dirId), Mockito.any())).thenReturn("cipherDir" + dirId);
 			Mockito.when(dirIdProvider.load(dirLinkFile)).thenReturn(nextDirId);
-			Mockito.when(fileNameCryptor.hashDirectoryId(nextDirId)).thenReturn("%04d".formatted(depth+1));
+			Mockito.when(fileNameCryptor.hashDirectoryId(nextDirId)).thenReturn("%04d".formatted(depth + 1));
 		}
 
 		var finalDirId = "%02d".formatted(maxNestingDepth);
-		Path finalContentDir = Mockito.mock(Path.class, "d/00/"+finalDirId);
-		Path finalEncryptedFile = Mockito.mock(Path.class, "d/00/"+finalDirId+"/file.c9r");
+		Path finalContentDir = Mockito.mock(Path.class, "d/00/" + finalDirId);
+		Path finalEncryptedFile = Mockito.mock(Path.class, "d/00/" + finalDirId + "/file.c9r");
 		Mockito.when(d00.resolve(finalDirId)).thenReturn(finalContentDir);
 		Mockito.when(finalContentDir.resolve("file.c9r")).thenReturn(finalEncryptedFile);
 		Mockito.when(fileNameCryptor.encryptFilename(Mockito.any(), Mockito.eq("cleartextFile"), Mockito.any())).thenReturn("file");
 
-		var testPath ="/"+ IntStream.range(0,maxNestingDepth).mapToObj("%02d"::formatted).collect(Collectors.joining("/"))+"/cleartextFile";
+		var testPath = "/" + IntStream.range(0, maxNestingDepth).mapToObj("%02d"::formatted).collect(Collectors.joining("/")) + "/cleartextFile";
 
 		CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig);
 		Path path = mapper.getCiphertextFilePath(fileSystem.getPath(testPath)).getRawPath();
@@ -210,6 +210,7 @@ public class CryptoPathMapperTest {
 		Path path = mapper.getCiphertextFilePath(fileSystem.getPath("/foo/bar/baz")).getRawPath();
 		Assertions.assertEquals(d0002zab, path);
 	}
+
 	@Nested
 	public class GetCiphertextFileType {
 
@@ -247,7 +248,7 @@ public class CryptoPathMapperTest {
 			Mockito.when(dirFilePath.getFileSystem()).thenReturn(underlyingFileSystem);
 			Mockito.when(symlinkFilePath.getFileSystem()).thenReturn(underlyingFileSystem);
 			Mockito.when(contentsFilePath.getFileSystem()).thenReturn(underlyingFileSystem);
-			
+
 		}
 
 

--- a/src/test/java/org/cryptomator/cryptofs/CryptoPathMapperTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/CryptoPathMapperTest.java
@@ -14,6 +14,7 @@ import org.cryptomator.cryptolib.api.Cryptor;
 import org.cryptomator.cryptolib.api.FileNameCryptor;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
@@ -26,6 +27,8 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.spi.FileSystemProvider;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class CryptoPathMapperTest {
 
@@ -133,6 +136,44 @@ public class CryptoPathMapperTest {
 		Assertions.assertEquals(d0002, path);
 	}
 
+	@DisplayName("Decrypts a deeply nested filepath")
+	@Test
+	public void testPathEncryptionDEEP() throws IOException {
+		Path d00 = Mockito.mock(Path.class, "d/00/");
+		Mockito.when(dataRoot.resolve("00")).thenReturn(d00);
+		Mockito.when(fileNameCryptor.hashDirectoryId("")).thenReturn("0000");
+
+		int maxNestingDepth = 9;
+
+		for (int depth=0; depth < maxNestingDepth; depth++) {
+			var dirId = "%02d".formatted(depth);
+			var nextDirId = "%02d".formatted(depth+1);
+			String pathPrefix = "d/00/"+dirId;
+			Path contentDir = Mockito.mock(Path.class, pathPrefix);
+			Path dirLinkDir = Mockito.mock(Path.class, pathPrefix+"/cipherDir"+dirId+".c9r");
+			Path dirLinkFile = Mockito.mock(Path.class, pathPrefix + "/cipherDir"+dirId+".c9r/dir.c9r");
+			Mockito.when(d00.resolve(dirId)).thenReturn(contentDir);
+			Mockito.when(contentDir.resolve("cipherDir"+dirId+".c9r")).thenReturn(dirLinkDir);
+			Mockito.when(dirLinkDir.resolve("dir.c9r")).thenReturn(dirLinkFile);
+			Mockito.when(fileNameCryptor.encryptFilename(Mockito.any(), Mockito.eq(dirId), Mockito.any())).thenReturn("cipherDir"+dirId);
+			Mockito.when(dirIdProvider.load(dirLinkFile)).thenReturn(nextDirId);
+			Mockito.when(fileNameCryptor.hashDirectoryId(nextDirId)).thenReturn("%04d".formatted(depth+1));
+		}
+
+		var finalDirId = "%02d".formatted(maxNestingDepth);
+		Path finalContentDir = Mockito.mock(Path.class, "d/00/"+finalDirId);
+		Path finalEncryptedFile = Mockito.mock(Path.class, "d/00/"+finalDirId+"/file.c9r");
+		Mockito.when(d00.resolve(finalDirId)).thenReturn(finalContentDir);
+		Mockito.when(finalContentDir.resolve("file.c9r")).thenReturn(finalEncryptedFile);
+		Mockito.when(fileNameCryptor.encryptFilename(Mockito.any(), Mockito.eq("cleartextFile"), Mockito.any())).thenReturn("file");
+
+		var testPath ="/"+ IntStream.range(0,maxNestingDepth).mapToObj("%02d"::formatted).collect(Collectors.joining("/"))+"/cleartextFile";
+
+		CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig);
+		Path path = mapper.getCiphertextFilePath(fileSystem.getPath(testPath)).getRawPath();
+		Assertions.assertEquals(finalEncryptedFile, path);
+	}
+
 	@Test
 	public void testPathEncryptionForFooBarBaz() throws IOException {
 		Path d00 = Mockito.mock(Path.class, "d/00/");
@@ -169,7 +210,6 @@ public class CryptoPathMapperTest {
 		Path path = mapper.getCiphertextFilePath(fileSystem.getPath("/foo/bar/baz")).getRawPath();
 		Assertions.assertEquals(d0002zab, path);
 	}
-
 	@Nested
 	public class GetCiphertextFileType {
 


### PR DESCRIPTION
Closes #180.

I applied the workaround described in [Caffeine wiki](https://github.com/ben-manes/caffeine/wiki/Faq#recursive-computations). Additonally, i checked all other spots where we use a `Cache` or `LoadingCache` for recursive updates:
* LongFileNameProvider
* ChunkCache
* DirectoryIdProvider

None of the above do such recursive updates, hence i left them untouched.