### PR TITLE
Feature: Refactor OWASP dependency check runs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "06:00"
-      timezone: "UTC"
+      timezone: "Etc/UTC"
     groups:
       java-test-dependencies:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "06:00"
-      timezone: "Etc/UTC"
+      timezone: "UTC"
     groups:
       java-test-dependencies:
         patterns:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,8 @@ jobs:
         with:
           name: artifacts
           path: target/*.jar
+      - uses: ./github/workflows/dependency-check.yml
+        secrets: inherit
       - name: Create release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,11 +40,6 @@ jobs:
         with:
           name: artifacts
           path: target/*.jar
-      - name: Check dependencies for releases
-        if: startsWith(github.ref, 'refs/tags/')
-        run: mvn -B verify -Pdependency-check -DskipTests
-        env:
-          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
       - name: Create release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           restore-keys: ${{ runner.os }}-sonar
       - name: Ensure to use tagged version
         if: startsWith(github.ref, 'refs/tags/')
-        run: mvn versions:set --file ./pom.xml -DnewVersion=${GITHUB_REF##*/}
+        run: mvn -B versions:set --file ./pom.xml -DnewVersion=${GITHUB_REF##*/}
       - name: Build and Test
         run: >
           mvn -B verify
@@ -40,8 +40,11 @@ jobs:
         with:
           name: artifacts
           path: target/*.jar
-      - uses: ./github/workflows/dependency-check.yml
-        secrets: inherit
+      - name: Check dependencies for releases
+        if: startsWith(github.ref, 'refs/tags/')
+        run: mvn -B verify -Pdependency-check -DskipTests
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
       - name: Create release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -2,7 +2,8 @@ name: OWASP Maven Dependency Check
 on:
   schedule:
     - cron: '0 7 * * 0'
-  workflow_call:
+  workflow_dispatch:
+
 
 jobs:
   check-dependencies:
@@ -21,7 +22,7 @@ jobs:
       - name: Run org.owasp:dependency-check plugin
         id: plugin-run
         continue-on-error: true
-        run: mvn verfiy -Pdependency-check
+        run: mvn -B verify -Pdependency-check -DskipTests
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
       - name: Upload report on failure

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -36,9 +36,15 @@ jobs:
           name: dependency-check-report
           path: target/dependency-check-report.html
           if-no-files-found: error
-      - name: Indicate failure, if necessary
-        if: "${{ steps.dependency-check.outcome == 'failure'}}"
-        shell: bash
-        run: |
-          echo "Dependency check failed! See uploaded report for details."
-          exit 1;
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_USERNAME: 'Cryptobot'
+          SLACK_ICON: false
+          SLACK_ICON_EMOJI: ':bot:'
+          SLACK_CHANNEL: 'cryptomator-desktop'
+          SLACK_TITLE: "Vulnerabilities in ${{ github.event.repository.name }} detected."
+          SLACK_MESSAGE: "Download the <https://github.com/${{ github.repository }}/actions/run/${{ github.run_id }}|report> for more details."
+          SLACK_FOOTER: false
+          MSG_MINIMAL: true

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,0 +1,39 @@
+name: OWASP Maven Dependency Check
+on:
+  schedule:
+    - cron: '0 7 * * 0'
+  workflow_call:
+
+jobs:
+  check-dependencies:
+    name: Check dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'maven'
+      - name: Run org.owasp:dependency-check plugin
+        id: plugin-run
+        continue-on-error: true
+        run: mvn verfiy -Pdependency-check
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+      - name: Upload report on failure
+        if: "${{ steps.plugin-run.outcome == 'failure'}}"
+        uses: actions/upload-artifact@v3
+        with:
+          name: dependency-check-report
+          path: target/dependency-check-report.html
+          if-no-files-found: error
+      - name: Indicate failure, if necessary
+        if: "${{ steps.plugin-run.outcome == 'failure'}}"
+        shell: bash
+        run: |
+          echo "Dependency check failed! See uploaded report for details."
+          exit 1;

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -2,6 +2,10 @@ name: OWASP Maven Dependency Check
 on:
   schedule:
     - cron: '0 7 * * 0'
+  push:
+    branches:
+      - 'release/**'
+      - 'hotfix/**'
   workflow_dispatch:
 
 
@@ -20,20 +24,20 @@ jobs:
           java-version: 17
           cache: 'maven'
       - name: Run org.owasp:dependency-check plugin
-        id: plugin-run
+        id: dependency-check
         continue-on-error: true
         run: mvn -B verify -Pdependency-check -DskipTests
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
       - name: Upload report on failure
-        if: "${{ steps.plugin-run.outcome == 'failure'}}"
+        if: "${{ steps.dependency-check.outcome == 'failure'}}"
         uses: actions/upload-artifact@v3
         with:
           name: dependency-check-report
           path: target/dependency-check-report.html
           if-no-files-found: error
       - name: Indicate failure, if necessary
-        if: "${{ steps.plugin-run.outcome == 'failure'}}"
+        if: "${{ steps.dependency-check.outcome == 'failure'}}"
         shell: bash
         run: |
           echo "Dependency check failed! See uploaded report for details."

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - 'release/**'
-      - 'hotfix/**'
   workflow_dispatch:
 
 
@@ -49,7 +48,7 @@ jobs:
           SLACK_MESSAGE: "Download the <https://github.com/${{ github.repository }}/actions/run/${{ github.run_id }}|report> for more details."
           SLACK_FOOTER: false
           MSG_MINIMAL: true
-      - name: Failing workflow on release/hotfix branch
+      - name: Failing workflow on release branch
         if: github.event_name == 'push' && steps.dependency-check.outcome == 'failure'
         shell: bash
         run: exit 1

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -37,7 +37,7 @@ jobs:
           path: target/dependency-check-report.html
           if-no-files-found: error
       - name: Slack Notification on regular check
-        if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule' && steps.dependency-check.outcome == 'failure'
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -50,6 +50,6 @@ jobs:
           SLACK_FOOTER: false
           MSG_MINIMAL: true
       - name: Failing workflow on release/hotfix branch
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && steps.dependency-check.outcome == 'failure'
         shell: bash
         run: exit 1

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
       - name: Upload report on failure
-        if: "${{ steps.dependency-check.outcome == 'failure'}}"
+        if: steps.dependency-check.outcome == 'failure'
         uses: actions/upload-artifact@v3
         with:
           name: dependency-check-report

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -36,7 +36,8 @@ jobs:
           name: dependency-check-report
           path: target/dependency-check-report.html
           if-no-files-found: error
-      - name: Slack Notification
+      - name: Slack Notification on regular check
+        if: github.event_name == 'schedule'
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -48,3 +49,7 @@ jobs:
           SLACK_MESSAGE: "Download the <https://github.com/${{ github.repository }}/actions/run/${{ github.run_id }}|report> for more details."
           SLACK_FOOTER: false
           MSG_MINIMAL: true
+      - name: Failing workflow on release/hotfix branch
+        if: github.event_name == 'push'
+        shell: bash
+        run: exit 1

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 		<jimfs.version>1.3.0</jimfs.version>
 
 		<!-- build plugin dependencies -->
-		<dependency-check.version>9.0.1</dependency-check.version>
+		<dependency-check.version>9.0.4</dependency-check.version>
 		<junit-tree-reporter.version>1.2.1</junit-tree-reporter.version>
 		<jacoco.version>0.8.11</jacoco.version>
 		<nexus-staging.version>1.6.13</nexus-staging.version>
@@ -247,11 +247,11 @@
 						<artifactId>dependency-check-maven</artifactId>
 						<version>${dependency-check.version}</version>
 						<configuration>
-							<cveValidForHours>24</cveValidForHours>
 							<failBuildOnCVSS>0</failBuildOnCVSS>
 							<skipTestScope>true</skipTestScope>
 							<detail>true</detail>
 							<suppressionFile>suppression.xml</suppressionFile>
+							<nvdApiKey>${env.NVD_API_KEY}</nvdApiKey>
 						</configuration>
 						<executions>
 							<execution>


### PR DESCRIPTION
This PRs changes the way, how we use the https://github.com/jeremylong/DependencyCheck maven plugin.

Changes were necessary due to the deprecation of an API used by dependency check (see [here](https://github.com/jeremylong/DependencyCheck#900-upgrade-notice) for details).

Changes:
* Plugin updated to 9.0.4
* plugin uses an NVD API key
* only before a release the plugin is executed
* once a week, the plugin is run on CI. If a vulnerability is detected, the workflow fails and the report is uploaded.
