### PR TITLE
Flush ciphertext channel before writing lastModified timestamp

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/ch/ChannelCloseListener.java
+++ b/src/main/java/org/cryptomator/cryptofs/ch/ChannelCloseListener.java
@@ -1,11 +1,11 @@
 package org.cryptomator.cryptofs.ch;
 
 
-import java.io.IOException;
+import java.nio.channels.FileChannel;
 
 @FunctionalInterface
 public interface ChannelCloseListener {
 
-	void closed(CleartextFileChannel channel) throws IOException;
+	void closed(FileChannel ciphertextChannel);
 
 }

--- a/src/main/java/org/cryptomator/cryptofs/fh/PriorityMutex.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/PriorityMutex.java
@@ -1,0 +1,108 @@
+package org.cryptomator.cryptofs.fh;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * Mutex with two (reentrant) states.
+ * <p>
+ * The mutex hands out redeemable tokens, depending on its state.
+ * There are two type of tokens, regular and priority ones.
+ * In the regular state, the mutex hands out regular tokens without blocking.
+ * On the first priority request, the mutex switches to priority state:
+ * * dispensing new regular tokens is blocked
+ * * priority requests block until the last dispensed regular token is redeemed.
+ * * afterward, all priority requests are handled without blocking
+ * <p>
+ * If the last handed out priority token is redeemed, the mutex switches back to its regular state, unblocking all regular requests.
+ * <p>
+ * Based on <a href="https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/concurrent/locks/LockSupport.html">an JDK example</a>
+ */
+public class PriorityMutex {
+
+
+	private final AtomicInteger counter = new AtomicInteger(0);
+	private final AtomicInteger handedOutRegularTokens = new AtomicInteger(0);
+	private final AtomicInteger priorityRequests = new AtomicInteger(0);
+	private final Map<Integer, Thread> regularLane = new ConcurrentHashMap<>();
+	private final Map<Integer, Thread> fastLane = new ConcurrentHashMap<>();
+
+	/**
+	 * Waits until all priority token requests are handled and redeemed and hands out a regular token.
+	 */
+	public Token dispenseRegular() {
+		boolean wasInterrupted = false;
+		// publish current thread to regular unparking lane
+		var tokenId = counter.incrementAndGet();
+		regularLane.put(tokenId, Thread.currentThread());
+
+		//Block while there are not handled or redeemed priority requests/tokens
+		while (priorityRequests.get() != 0) {
+			LockSupport.park(this);
+			// ignore interrupts while waiting
+			if (Thread.interrupted()) wasInterrupted = true;
+		}
+		handedOutRegularTokens.incrementAndGet();
+		regularLane.remove(tokenId);
+		// ensure correct interrupt status on return
+		if (wasInterrupted) Thread.currentThread().interrupt();
+		return () -> {
+			handedOutRegularTokens.decrementAndGet();
+			redeem();
+		};
+	}
+
+	/**
+	 * Waits until all handed-out regular tokens are redeemed and hands out a priority token.
+	 */
+	public Token dispensePriority() {
+		priorityRequests.incrementAndGet();
+		boolean wasInterrupted = false;
+		// publish current thread to priority unparking lane
+		var tokenId = counter.incrementAndGet();
+		fastLane.put(tokenId, Thread.currentThread());
+
+		//Block while there are not redeemed regular tokens
+		while (handedOutRegularTokens.get() != 0) {
+			LockSupport.park(this);
+			// ignore interrupts while waiting
+			if (Thread.interrupted()) wasInterrupted = true;
+		}
+
+		fastLane.remove(tokenId);
+		// ensure correct interrupt status on return
+		if (wasInterrupted) Thread.currentThread().interrupt();
+		return () -> {
+			priorityRequests.decrementAndGet();
+			redeem();
+		};
+	}
+
+	private void redeem() {
+		if (priorityRequests.get() != 0) {
+			fastLane.forEach((id, thread) -> LockSupport.unpark(thread));
+		} else {
+			regularLane.forEach((id, thread) -> LockSupport.unpark(thread));
+		}
+	}
+
+	static {
+		// Reduce the risk of "lost unpark" due to classloading
+		Class<?> ensureLoaded = LockSupport.class;
+	}
+
+	@FunctionalInterface
+	interface Token extends AutoCloseable {
+
+		void redeem();
+
+		default void close() {
+			redeem();
+		}
+	}
+
+	;
+
+}

--- a/src/test/java/org/cryptomator/cryptofs/ch/CleartextFileChannelTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/ch/CleartextFileChannelTest.java
@@ -43,7 +43,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
-import java.util.function.Supplier;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -69,7 +68,7 @@ public class CleartextFileChannelTest {
 	private FileHeaderHolder headerHolder = mock(FileHeaderHolder.class);
 	private AtomicBoolean headerIsPersisted = mock(AtomicBoolean.class);
 	private EffectiveOpenOptions options = mock(EffectiveOpenOptions.class);
-	private Path filePath = Mockito.mock(Path.class,"/foo/bar");
+	private Path filePath = Mockito.mock(Path.class, "/foo/bar");
 	private AtomicReference<Path> currentFilePath = new AtomicReference<>(filePath);
 	private AtomicLong fileSize = new AtomicLong(100);
 	private AtomicReference<Instant> lastModified = new AtomicReference<>(Instant.ofEpochMilli(0));
@@ -96,7 +95,7 @@ public class CleartextFileChannelTest {
 		var fsProvider = Mockito.mock(FileSystemProvider.class);
 		when(filePath.getFileSystem()).thenReturn(fs);
 		when(fs.provider()).thenReturn(fsProvider);
-		when(fsProvider.getFileAttributeView(filePath,BasicFileAttributeView.class)).thenReturn(attributeView);
+		when(fsProvider.getFileAttributeView(filePath, BasicFileAttributeView.class)).thenReturn(attributeView);
 		when(readWriteLock.readLock()).thenReturn(readLock);
 		when(readWriteLock.writeLock()).thenReturn(writeLock);
 

--- a/src/test/java/org/cryptomator/cryptofs/ch/CleartextFileChannelTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/ch/CleartextFileChannelTest.java
@@ -233,7 +233,7 @@ public class CleartextFileChannelTest {
 	public class Close {
 
 		@Test
-		@DisplayName("IOException during flush still cleans up")
+		@DisplayName("IOException during flush cleans up and rethrows")
 		public void testCloseIoExceptionFlush() throws IOException {
 			var inSpy = Mockito.spy(inTest);
 			Mockito.doThrow(IOException.class).when(inSpy).flush();
@@ -243,7 +243,7 @@ public class CleartextFileChannelTest {
 		}
 
 		@Test
-		@DisplayName("IOException during ciphertextChannel.force() still cleans up")
+		@DisplayName("IOException during ciphertextChannel.force() cleans up and rethrows")
 		public void testCloseIoExceptionForce() throws IOException {
 			var inSpy = Mockito.spy(inTest);
 			Mockito.doThrow(IOException.class).when(ciphertextFileChannel).force(Mockito.anyBoolean());
@@ -264,7 +264,7 @@ public class CleartextFileChannelTest {
 		}
 
 		@Test
-		@DisplayName("IOException on persisting lastModified during close is ignored")
+		@DisplayName("IOException on persisting lastModified during close cleans up but ignored")
 		public void testCloseExceptionOnLastModifiedPersistenceIgnored() throws IOException {
 			when(options.writable()).thenReturn(true);
 			lastModified.set(Instant.ofEpochMilli(123456789000l));
@@ -273,7 +273,8 @@ public class CleartextFileChannelTest {
 			Mockito.doThrow(IOException.class).when(inSpy).persistLastModified();
 
 			Assertions.assertDoesNotThrow(() -> inSpy.implCloseChannel());
-
+			verify(closeListener).closed(ciphertextFileChannel);
+			verify(ciphertextFileChannel).close();
 		}
 
 		@Test

--- a/src/test/java/org/cryptomator/cryptofs/fh/OpenCryptoFileTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/fh/OpenCryptoFileTest.java
@@ -280,7 +280,7 @@ public class OpenCryptoFileTest {
 			Assumptions.assumeTrue(listener.get() != null);
 			Assumptions.assumeTrue(ciphertextChannel.get() != null);
 
-			listener.get().closed(cleartextFileChannel);
+			listener.get().closed(ciphertextChannel.get());
 			verify(chunkIO).unregisterChannel(ciphertextChannel.get());
 		}
 


### PR DESCRIPTION
Fixes #205.

Unfortunately, the changes became bigger than anticipated. Reason is, that due to our ..."spaghetti" architecture, with the minimal fix could not exclude the possibility that the lastModified timestamp is not overwritten. The chunkCache uses an arbitrary ciphertext filechannel to write to a file via the `ChunkIO` class. It was theoretically possible to first get a writable channel but deregister this channel in a different thread. With my implementation one can either deregister channels to the same file or write into such channels, but cannot do both. Deregistering is prioritized to timely finish close actions.

With this PR we have now the guarantee, that between a ciphertext channels `force(...)` and `close()` method, no other thread can write to it, hence persisting the lastModified timestamp can only fail on the storage side. Additionally, i moved all IO-related things during close to the `CleartextFileChannel` (some were lingering around in `OpenCryptoFile`) and improved the unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a more sophisticated synchronization mechanism for file operations, enhancing thread safety and performance.
- **Refactor**
	- Updated file channel handling to improve reliability and efficiency in file operations.
	- Simplified file channel interaction for better maintainability.
- **Bug Fixes**
	- Adjusted file channel closure handling to ensure proper resource management.
- **Tests**
	- Enhanced testing for file channel operations, including handling of `IOExceptions`.
	- Improved test accuracy by refining mock object creation and method calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->