### PR TITLE
Feature: Flush cipherChannel before persisting lastModifed

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/ch/CleartextFileChannel.java
+++ b/src/main/java/org/cryptomator/cryptofs/ch/CleartextFileChannel.java
@@ -322,6 +322,7 @@ public class CleartextFileChannel extends AbstractFileChannel {
 	protected void implCloseChannel() throws IOException {
 		try {
 			flush();
+			ciphertextFileChannel.force(true);
 			try {
 				persistLastModified();
 			} catch (NoSuchFileException nsfe) {

--- a/src/main/java/org/cryptomator/cryptofs/ch/CleartextFileChannel.java
+++ b/src/main/java/org/cryptomator/cryptofs/ch/CleartextFileChannel.java
@@ -1,5 +1,6 @@
 package org.cryptomator.cryptofs.ch;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.cryptomator.cryptofs.CryptoFileSystemStats;
 import org.cryptomator.cryptofs.EffectiveOpenOptions;
@@ -245,7 +246,8 @@ public class CleartextFileChannel extends AbstractFileChannel {
 	 *
 	 * @throws IOException
 	 */
-	private void persistLastModified() throws IOException {
+	@VisibleForTesting
+	void persistLastModified() throws IOException {
 		FileTime lastModifiedTime = isWritable() ? FileTime.from(lastModified.get()) : null;
 		FileTime lastAccessTime = FileTime.from(Instant.now());
 		var p = currentFilePath.get();

--- a/src/test/java/org/cryptomator/cryptofs/ch/CleartextFileChannelTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/ch/CleartextFileChannelTest.java
@@ -51,7 +51,9 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -238,6 +240,17 @@ public class CleartextFileChannelTest {
 			inTest.implCloseChannel();
 
 			verify(closeListener).closed(inTest);
+		}
+
+		@Test
+		@DisplayName("On close, first flush channel, then persist lastModified")
+		public void testCloseFlushBeforePersist() throws IOException {
+			var inSpy = spy(inTest);
+			inSpy.implCloseChannel();
+
+			var ordering = inOrder(inSpy, ciphertextFileChannel);
+			ordering.verify(ciphertextFileChannel).force(true);
+			ordering.verify(inSpy).persistLastModified();
 		}
 
 		@Test


### PR DESCRIPTION
Fixes #205.

See also https://github.com/cryptomator/cryptofs/issues/205#issuecomment-1935819583.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the reliability of file handling during close operations.
- **Tests**
	- Added new tests to ensure file changes are correctly persisted upon closing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->