### PR TITLE
Feature: First close file channel, then persist lastModified

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/attr/CryptoBasicFileAttributeView.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/CryptoBasicFileAttributeView.java
@@ -48,10 +48,10 @@ sealed class CryptoBasicFileAttributeView extends AbstractCryptoFileAttributeVie
 	@Override
 	public void setTimes(FileTime lastModifiedTime, FileTime lastAccessTime, FileTime createTime) throws IOException {
 		readonlyFlag.assertWritable();
-		getCiphertextAttributeView(BasicFileAttributeView.class).setTimes(lastModifiedTime, lastAccessTime, createTime);
 		if (lastModifiedTime != null) {
 			getOpenCryptoFile().ifPresent(file -> file.setLastModifiedTime(lastModifiedTime));
 		}
+		getCiphertextAttributeView(BasicFileAttributeView.class).setTimes(lastModifiedTime, lastAccessTime, createTime);
 	}
 
 }

--- a/src/main/java/org/cryptomator/cryptofs/ch/ChannelCloseListener.java
+++ b/src/main/java/org/cryptomator/cryptofs/ch/ChannelCloseListener.java
@@ -1,11 +1,9 @@
 package org.cryptomator.cryptofs.ch;
 
 
-import java.io.IOException;
-
 @FunctionalInterface
 public interface ChannelCloseListener {
 
-	void closed(CleartextFileChannel channel) throws IOException;
+	void closed(CleartextFileChannel channel);
 
 }

--- a/src/main/java/org/cryptomator/cryptofs/ch/CleartextFileChannel.java
+++ b/src/main/java/org/cryptomator/cryptofs/ch/CleartextFileChannel.java
@@ -326,19 +326,29 @@ public class CleartextFileChannel extends AbstractFileChannel {
 		try {
 			flush();
 		} finally {
+			implCloseChannelFinally1();
+		}
+	}
+
+	private void implCloseChannelFinally1() throws IOException {
+		try {
 			super.implCloseChannel();
+		} finally {
 			closeListener.closed(this);
+			implCloseChannelFinally2();
+		}
+	}
+
+	private void implCloseChannelFinally2() throws IOException {
+		try {
+			ciphertextFileChannel.close();
+		} finally {
 			try {
-				ciphertextFileChannel.close();
-			} finally {
-				try {
-					persistLastModified();
-				} catch (NoSuchFileException nsfe) {
-					//no-op, see https://github.com/cryptomator/cryptofs/issues/169
-				} catch (IOException e) {
-					//only best effort attempt
-					LOG.warn("Failed to persist last modified timestamp for encrypted file: {}", e.getMessage());
-				}
+				persistLastModified();
+			} catch (NoSuchFileException nsfe) {
+				//no-op, see https://github.com/cryptomator/cryptofs/issues/169
+			} catch (IOException e) {
+				LOG.warn("Failed to persist last modified timestamp for encrypted file: {}", e.getMessage());
 			}
 		}
 	}

--- a/src/main/java/org/cryptomator/cryptofs/ch/CleartextFileChannel.java
+++ b/src/main/java/org/cryptomator/cryptofs/ch/CleartextFileChannel.java
@@ -322,6 +322,10 @@ public class CleartextFileChannel extends AbstractFileChannel {
 	protected void implCloseChannel() throws IOException {
 		try {
 			flush();
+		} finally {
+			super.implCloseChannel();
+			closeListener.closed(this);
+			ciphertextFileChannel.close();
 			try {
 				persistLastModified();
 			} catch (NoSuchFileException nsfe) {
@@ -330,9 +334,6 @@ public class CleartextFileChannel extends AbstractFileChannel {
 				//only best effort attempt
 				LOG.warn("Failed to persist last modified timestamp for encrypted file: {}", e.getMessage());
 			}
-		} finally {
-			super.implCloseChannel();
-			closeListener.closed(this);
 		}
 	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/ch/CleartextFileChannel.java
+++ b/src/main/java/org/cryptomator/cryptofs/ch/CleartextFileChannel.java
@@ -1,5 +1,6 @@
 package org.cryptomator.cryptofs.ch;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.cryptomator.cryptofs.CryptoFileSystemStats;
 import org.cryptomator.cryptofs.EffectiveOpenOptions;
@@ -232,7 +233,8 @@ public class CleartextFileChannel extends AbstractFileChannel {
 	 *
 	 * @throws IOException
 	 */
-	private void flush() throws IOException {
+	@VisibleForTesting
+	void flush() throws IOException {
 		if (isWritable()) {
 			writeHeaderIfNeeded();
 			chunkCache.flush();
@@ -245,7 +247,8 @@ public class CleartextFileChannel extends AbstractFileChannel {
 	 *
 	 * @throws IOException
 	 */
-	private void persistLastModified() throws IOException {
+	@VisibleForTesting
+	void persistLastModified() throws IOException {
 		FileTime lastModifiedTime = isWritable() ? FileTime.from(lastModified.get()) : null;
 		FileTime lastAccessTime = FileTime.from(Instant.now());
 		var p = currentFilePath.get();

--- a/src/main/java/org/cryptomator/cryptofs/ch/CleartextFileChannel.java
+++ b/src/main/java/org/cryptomator/cryptofs/ch/CleartextFileChannel.java
@@ -328,14 +328,17 @@ public class CleartextFileChannel extends AbstractFileChannel {
 		} finally {
 			super.implCloseChannel();
 			closeListener.closed(this);
-			ciphertextFileChannel.close();
 			try {
-				persistLastModified();
-			} catch (NoSuchFileException nsfe) {
-				//no-op, see https://github.com/cryptomator/cryptofs/issues/169
-			} catch (IOException e) {
-				//only best effort attempt
-				LOG.warn("Failed to persist last modified timestamp for encrypted file: {}", e.getMessage());
+				ciphertextFileChannel.close();
+			} finally {
+				try {
+					persistLastModified();
+				} catch (NoSuchFileException nsfe) {
+					//no-op, see https://github.com/cryptomator/cryptofs/issues/169
+				} catch (IOException e) {
+					//only best effort attempt
+					LOG.warn("Failed to persist last modified timestamp for encrypted file: {}", e.getMessage());
+				}
 			}
 		}
 	}

--- a/src/main/java/org/cryptomator/cryptofs/fh/OpenCryptoFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/OpenCryptoFile.java
@@ -183,17 +183,13 @@ public class OpenCryptoFile implements Closeable {
 		currentFilePath.updateAndGet(p -> p == null ? null : newFilePath);
 	}
 
-	private synchronized void channelClosed(CleartextFileChannel cleartextFileChannel) throws IOException {
-		try {
-			FileChannel ciphertextFileChannel = openChannels.remove(cleartextFileChannel);
-			if (ciphertextFileChannel != null) {
-				chunkIO.unregisterChannel(ciphertextFileChannel);
-				ciphertextFileChannel.close();
-			}
-		} finally {
-			if (openChannels.isEmpty()) {
-				close();
-			}
+	private synchronized void channelClosed(CleartextFileChannel cleartextFileChannel) {
+		FileChannel ciphertextFileChannel = openChannels.remove(cleartextFileChannel);
+		if (ciphertextFileChannel != null) {
+			chunkIO.unregisterChannel(ciphertextFileChannel);
+		}
+		if (openChannels.isEmpty()) {
+			close();
 		}
 	}
 

--- a/src/test/java/org/cryptomator/cryptofs/ch/CleartextFileChannelTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/ch/CleartextFileChannelTest.java
@@ -248,13 +248,13 @@ public class CleartextFileChannelTest {
 		}
 
 		@Test
-		@DisplayName("On close, first flush channel, then persist lastModified")
-		public void testCloseFlushBeforePersist() throws IOException {
+		@DisplayName("On close, first close channel, then persist lastModified")
+		public void testCloseCipherChannelCloseBeforePersist() throws IOException {
 			var inSpy = spy(inTest);
 			inSpy.implCloseChannel();
 
 			var ordering = inOrder(inSpy, ciphertextFileChannel);
-			ordering.verify(ciphertextFileChannel).force(true);
+			ordering.verify(ciphertextFileChannel).close();
 			ordering.verify(inSpy).persistLastModified();
 		}
 


### PR DESCRIPTION
This PR changes the logic of persisting the lastModfied date from _before_ closing the ciphertext channel to _afterwards_. Additionally, the cryptofs internal lastModifiedDate is always updated, even when persisting to storage fails.

This impl change is motivated by the behaviour of some fs/storage implemenations, which set the lastModified time to "now" when closing a channel, regardless of changes made.

Before merging, we should test the implementation with different scenarios:
|         | OneDrive | pCloud | GoogleDrive | iCloud | Dropbox | LocalFS |
|---------|----------|--------|-------------|--------|----------|----------|
| Windows |      ✅    |  ✅    |     ✅         |   ❓1      |      ✅    |     ✅    |
| macOS   |     ✅     |   ✅     |     ✅        |   ✅     |  ✅ | ✅  | 
| Linux   |    ➖ 2      |   ➖ 2     |    ➖ 2      |   ➖ 2   | ➖ 2   |  ✅  |

The test was to edit and save an spreadsheet/document file and copying files of different sizes into the vault.

1: iCloud on Windows is... strange. First of all, everything copied into the iCloud dir gets as mTime the _current_ time. Inside a Cryptomator vault, this becomes even stranger. Sometimes, the files are set to the current time, but especially bigger files (<30MB) get ... "some" time. "Some" can be the current, the former file mTime or something in between.

2: On Linux there are no offical filesystem integrations. GNOME offers "online account", but these are not accessible from the filesystem.