### PR TITLE
Feature: Refactor filesystem checker

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystems.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystems.java
@@ -53,13 +53,12 @@ class CryptoFileSystems {
 		try (Masterkey key = properties.keyLoader().loadKey(keyId)) {
 			var config = configLoader.verify(key.getEncoded(), Constants.VAULT_VERSION);
 			backupVaultConfigFile(normalizedPathToVault, properties);
-			var adjustedProperties = adjustForCapabilities(pathToVault, properties);
 			var cryptor = CryptorProvider.forScheme(config.getCipherCombo()).provide(key.copy(), csprng);
 			try {
 				checkVaultRootExistence(pathToVault, cryptor);
 				return fileSystems.compute(normalizedPathToVault, (path, fs) -> {
 					if (fs == null) {
-						return cryptoFileSystemComponentFactory.create(cryptor, config, provider, normalizedPathToVault, adjustedProperties).cryptoFileSystem();
+						return cryptoFileSystemComponentFactory.create(cryptor, config, provider, normalizedPathToVault, properties).cryptoFileSystem();
 					} else {
 						throw new FileSystemAlreadyExistsException();
 					}
@@ -121,23 +120,6 @@ class CryptoFileSystems {
 	private void backupVaultConfigFile(Path pathToVault, CryptoFileSystemProperties properties) throws IOException {
 		Path vaultConfigFile = pathToVault.resolve(properties.vaultConfigFilename());
 		BackupHelper.attemptBackup(vaultConfigFile);
-	}
-
-	private CryptoFileSystemProperties adjustForCapabilities(Path pathToVault, CryptoFileSystemProperties originalProperties) throws FileSystemCapabilityChecker.MissingCapabilityException {
-		if (!originalProperties.readonly()) {
-			try {
-				capabilityChecker.assertWriteAccess(pathToVault);
-				return originalProperties;
-			} catch (FileSystemCapabilityChecker.MissingCapabilityException e) {
-				capabilityChecker.assertReadAccess(pathToVault);
-				LOG.warn("No write access to vault. Fallback to read-only access.");
-				Set<CryptoFileSystemProperties.FileSystemFlags> flags = EnumSet.copyOf(originalProperties.flags());
-				flags.add(CryptoFileSystemProperties.FileSystemFlags.READONLY);
-				return CryptoFileSystemProperties.cryptoFileSystemPropertiesFrom(originalProperties).withFlags(flags).build();
-			}
-		} else {
-			return originalProperties;
-		}
 	}
 
 	public void remove(CryptoFileSystemImpl cryptoFileSystem) {

--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystems.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystems.java
@@ -34,13 +34,11 @@ class CryptoFileSystems {
 
 	private final ConcurrentMap<Path, CryptoFileSystemImpl> fileSystems = new ConcurrentHashMap<>();
 	private final CryptoFileSystemComponent.Factory cryptoFileSystemComponentFactory;
-	private final FileSystemCapabilityChecker capabilityChecker;
 	private final SecureRandom csprng;
 
 	@Inject
-	public CryptoFileSystems(CryptoFileSystemComponent.Factory cryptoFileSystemComponentFactory, FileSystemCapabilityChecker capabilityChecker, SecureRandom csprng) {
+	public CryptoFileSystems(CryptoFileSystemComponent.Factory cryptoFileSystemComponentFactory, SecureRandom csprng) {
 		this.cryptoFileSystemComponentFactory = cryptoFileSystemComponentFactory;
-		this.capabilityChecker = capabilityChecker;
 		this.csprng = csprng;
 	}
 

--- a/src/main/java/org/cryptomator/cryptofs/migration/MigrationModule.java
+++ b/src/main/java/org/cryptomator/cryptofs/migration/MigrationModule.java
@@ -26,11 +26,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 class MigrationModule {
 
 	@Provides
-	FileSystemCapabilityChecker provideFileSystemCapabilityChecker() {
-		return new FileSystemCapabilityChecker();
-	}
-
-	@Provides
 	@IntoMap
 	@MigratorKey(Migration.FIVE_TO_SIX)
 	Migrator provideVersion6Migrator(Version6Migrator migrator) {

--- a/src/main/java/org/cryptomator/cryptofs/migration/Migrators.java
+++ b/src/main/java/org/cryptomator/cryptofs/migration/Migrators.java
@@ -46,12 +46,10 @@ public class Migrators {
 	private static final MigrationComponent COMPONENT = DaggerMigrationComponent.builder().csprng(strongSecureRandom()).build();
 
 	private final Map<Migration, Migrator> migrators;
-	private final FileSystemCapabilityChecker fsCapabilityChecker;
 
 	@Inject
-	Migrators(Map<Migration, Migrator> migrators, FileSystemCapabilityChecker fsCapabilityChecker) {
+	Migrators(Map<Migration, Migrator> migrators) {
 		this.migrators = migrators;
-		this.fsCapabilityChecker = fsCapabilityChecker;
 	}
 
 	private static SecureRandom strongSecureRandom() {
@@ -69,9 +67,9 @@ public class Migrators {
 	/**
 	 * Inspects the vault and checks if it is supported by this library.
 	 *
-	 * @param pathToVault         Path to the vault's root
+	 * @param pathToVault Path to the vault's root
 	 * @param vaultConfigFilename Name of the vault config file located in the vault
-	 * @param masterkeyFilename   Name of the masterkey file optionally located in the vault
+	 * @param masterkeyFilename Name of the masterkey file optionally located in the vault
 	 * @return <code>true</code> if the vault at the given path is of an older format than supported by this library
 	 * @throws IOException if an I/O error occurs parsing the masterkey file
 	 */
@@ -83,19 +81,19 @@ public class Migrators {
 	/**
 	 * Performs the actual migration. This task may take a while and this method will block.
 	 *
-	 * @param pathToVault          Path to the vault's root
-	 * @param vaultConfigFilename  Name of the vault config file located inside <code>pathToVault</code>
-	 * @param masterkeyFilename    Name of the masterkey file located inside <code>pathToVault</code>
-	 * @param passphrase           The passphrase needed to unlock the vault
-	 * @param progressListener     Listener that will get notified of progress updates
+	 * @param pathToVault Path to the vault's root
+	 * @param vaultConfigFilename Name of the vault config file located inside <code>pathToVault</code>
+	 * @param masterkeyFilename Name of the masterkey file located inside <code>pathToVault</code>
+	 * @param passphrase The passphrase needed to unlock the vault
+	 * @param progressListener Listener that will get notified of progress updates
 	 * @param continuationListener Listener that will get asked if there are events that require feedback
-	 * @throws NoApplicableMigratorException                          If the vault can not be migrated, because no migrator could be found
-	 * @throws InvalidPassphraseException                             If the passphrase could not be used to unlock the vault
+	 * @throws NoApplicableMigratorException If the vault can not be migrated, because no migrator could be found
+	 * @throws InvalidPassphraseException If the passphrase could not be used to unlock the vault
 	 * @throws FileSystemCapabilityChecker.MissingCapabilityException If the underlying filesystem lacks features required to store a vault
-	 * @throws IOException                                            if an I/O error occurs migrating the vault
+	 * @throws IOException if an I/O error occurs migrating the vault
 	 */
 	public void migrate(Path pathToVault, String vaultConfigFilename, String masterkeyFilename, CharSequence passphrase, MigrationProgressListener progressListener, MigrationContinuationListener continuationListener) throws NoApplicableMigratorException, CryptoException, IOException {
-		fsCapabilityChecker.assertAllCapabilities(pathToVault);
+		FileSystemCapabilityChecker.assertAllCapabilities(pathToVault);
 		int vaultVersion = determineVaultVersion(pathToVault, vaultConfigFilename, masterkeyFilename);
 		try {
 			Migrator migrator = findApplicableMigrator(vaultVersion).orElseThrow(NoApplicableMigratorException::new);

--- a/src/main/java/org/cryptomator/cryptofs/migration/v7/Version7Migrator.java
+++ b/src/main/java/org/cryptomator/cryptofs/migration/v7/Version7Migrator.java
@@ -66,7 +66,7 @@ public class Version7Migrator implements Migrator {
 			LOG.info("Backed up masterkey from {} to {}.", masterkeyFile.getFileName(), masterkeyBackupFile.getFileName());
 
 			// check file system capabilities:
-			int filenameLengthLimit = new FileSystemCapabilityChecker().determineSupportedCiphertextFileNameLength(vaultRoot.resolve("c"), 46, 28, 220);
+			int filenameLengthLimit = FileSystemCapabilityChecker.determineSupportedCiphertextFileNameLength(vaultRoot.resolve("c"), 46, 28, 220);
 			int pathLengthLimit = filenameLengthLimit + 48; // TODO
 			PreMigrationVisitor preMigrationVisitor;
 			if (filenameLengthLimit >= 220) {

--- a/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemsTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/CryptoFileSystemsTest.java
@@ -41,7 +41,6 @@ public class CryptoFileSystemsTest {
 	private final Path dataDirPath = mock(Path.class, "normalizedVaultPath/d");
 	private final Path preContenRootPath = mock(Path.class, "normalizedVaultPath/d/AB");
 	private final Path contenRootPath = mock(Path.class, "normalizedVaultPath/d/AB/CDEFGHIJKLMNOP");
-	private final FileSystemCapabilityChecker capabilityChecker = mock(FileSystemCapabilityChecker.class);
 	private final CryptoFileSystemProvider provider = mock(CryptoFileSystemProvider.class);
 	private final CryptoFileSystemProperties properties = mock(CryptoFileSystemProperties.class);
 	private final CryptoFileSystemComponent cryptoFileSystemComponent = mock(CryptoFileSystemComponent.class);
@@ -65,7 +64,7 @@ public class CryptoFileSystemsTest {
 	private MockedStatic<CryptorProvider> cryptorProviderClass;
 	private MockedStatic<BackupHelper> backupHelperClass;
 
-	private final CryptoFileSystems inTest = new CryptoFileSystems(cryptoFileSystemComponentFactory, capabilityChecker, csprng);
+	private final CryptoFileSystems inTest = new CryptoFileSystems(cryptoFileSystemComponentFactory, csprng);
 
 	@BeforeEach
 	public void setup() throws IOException, MasterkeyLoadingFailedException {


### PR DESCRIPTION
This PR does two, related things:

1. Removes the implicit read-only flag, if the storage location is read only.
1. Refactors the `FileSystemCapabilityChecker` class to be static only

## Motivation
>Imagine, someone needs a tshirt and decides to order a green one. Unfortunately, she gets a red one, because green is out of stock. Not cool, she wanted a green one. Instead, the customer should have been informed about the the low stock and _asked_ what to do.
One can argue, but the color does not matter, since you can always wear the shirt. But we don't know the purpose of the shirt. If it is used in a green screen setting, red is definitively a bad color.

This PR applies the principle behind the short story when creating the cryptographic filesystem. The implicit change from read/write to read-only, if the storage location is read-only, is removed.

Additionaly, the FileSystemChecker is converted to a static only class.
