### PR TITLE
Use truncate() of CleartextChannel when opening new Channel with `TRUNCATE_EXISTING`

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/fh/OpenCryptoFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/OpenCryptoFile.java
@@ -70,15 +70,13 @@ public class OpenCryptoFile implements Closeable {
 		try {
 			ciphertextFileChannel = path.getFileSystem().provider().newFileChannel(path, options.createOpenOptionsForEncryptedFile(), attrs);
 			initFileHeader(options, ciphertextFileChannel);
-			if (options.truncateExisting()) {
-				chunkCache.invalidateStale();
-				ciphertextFileChannel.truncate(cryptor.fileHeaderCryptor().headerSize());
-				fileSize.set(0);
-			}
 			initFileSize(ciphertextFileChannel);
 			cleartextFileChannel = component.newChannelComponent() //
 					.create(ciphertextFileChannel, options, this::cleartextChannelClosed) //
 					.channel();
+			if (options.truncateExisting()) {
+				cleartextFileChannel.truncate(0);
+			}
 		} finally {
 			if (cleartextFileChannel == null) { // i.e. something didn't work
 				cleartextChannelClosed(ciphertextFileChannel);

--- a/src/main/java/org/cryptomator/cryptofs/fh/OpenCryptoFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/OpenCryptoFile.java
@@ -26,7 +26,6 @@ public class OpenCryptoFile implements Closeable {
 
 	private final FileCloseListener listener;
 	private final AtomicReference<Instant> lastModified;
-	private final ChunkCache chunkCache;
 	private final Cryptor cryptor;
 	private final FileHeaderHolder headerHolder;
 	private final ChunkIO chunkIO;
@@ -37,11 +36,10 @@ public class OpenCryptoFile implements Closeable {
 	private final AtomicInteger openChannelsCount = new AtomicInteger(0);
 
 	@Inject
-	public OpenCryptoFile(FileCloseListener listener, ChunkCache chunkCache, Cryptor cryptor, FileHeaderHolder headerHolder, ChunkIO chunkIO, //
+	public OpenCryptoFile(FileCloseListener listener, Cryptor cryptor, FileHeaderHolder headerHolder, ChunkIO chunkIO, //
 						  @CurrentOpenFilePath AtomicReference<Path> currentFilePath, @OpenFileSize AtomicLong fileSize, //
 						  @OpenFileModifiedDate AtomicReference<Instant> lastModified, OpenCryptoFileComponent component) {
 		this.listener = listener;
-		this.chunkCache = chunkCache;
 		this.cryptor = cryptor;
 		this.headerHolder = headerHolder;
 		this.chunkIO = chunkIO;

--- a/src/test/java/org/cryptomator/cryptofs/CryptoFileChannelWriteReadIntegrationTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/CryptoFileChannelWriteReadIntegrationTest.java
@@ -618,7 +618,7 @@ public class CryptoFileChannelWriteReadIntegrationTest {
 		}
 
 		@RepeatedTest(10)
-		public void testConcurrentWriteAndTruncate() throws IOException, InterruptedException {
+		void testConcurrentWriteAndTruncate() throws IOException, InterruptedException {
 			AtomicBoolean keepWriting = new AtomicBoolean(true);
 			ByteBuffer buf = ByteBuffer.wrap("the quick brown fox jumps over the lazy dog".getBytes(StandardCharsets.UTF_8));
 			var timer = new CountDownLatch(1);

--- a/src/test/java/org/cryptomator/cryptofs/CryptoFileChannelWriteReadIntegrationTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/CryptoFileChannelWriteReadIntegrationTest.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -617,13 +618,14 @@ public class CryptoFileChannelWriteReadIntegrationTest {
 			Assertions.assertEquals(-1, bytesRead);
 		}
 
-		@RepeatedTest(10)
-		void testConcurrentWriteAndTruncate() throws IOException, InterruptedException {
+		@RepeatedTest(50)
+		public void testConcurrentWriteAndTruncate() throws IOException, InterruptedException {
 			AtomicBoolean keepWriting = new AtomicBoolean(true);
-			ByteBuffer buf = ByteBuffer.wrap("the quick brown fox jumps over the lazy dog".getBytes(StandardCharsets.UTF_8));
-			var timer = new CountDownLatch(1);
-			var executor = Executors.newCachedThreadPool();
-			try (FileChannel writingChannel = FileChannel.open(file, WRITE, CREATE)) {
+			ByteBuffer buf = ByteBuffer.allocate(50_000); // 50 kiB
+
+			try (ExecutorService executor = Executors.newCachedThreadPool();
+				 FileChannel writingChannel = FileChannel.open(file, WRITE, CREATE)) {
+				var cdl = new CountDownLatch(3);
 				executor.submit(() -> {
 					while (keepWriting.get()) {
 						try {
@@ -632,21 +634,22 @@ public class CryptoFileChannelWriteReadIntegrationTest {
 							throw new UncheckedIOException(e);
 						}
 						buf.flip();
+						cdl.countDown();
 					}
 				});
-				timer.await(500, TimeUnit.MILLISECONDS);
+				cdl.await();
 				try (FileChannel truncatingChannel = FileChannel.open(file, WRITE, TRUNCATE_EXISTING)) {
 					keepWriting.set(false);
 				}
-				executor.shutdown();
 			}
 
-			Assertions.assertDoesNotThrow(() -> {
-				try (FileChannel readingChannel = FileChannel.open(file, READ)) {
-					var dst = ByteBuffer.allocate(buf.capacity());
+
+			try (FileChannel readingChannel = FileChannel.open(file, READ)) {
+				var dst = ByteBuffer.allocate(buf.capacity());
+				Assertions.assertDoesNotThrow(() -> {
 					readingChannel.read(dst);
-				}
-			});
+				});
+			}
 		}
 
 	}

--- a/src/test/java/org/cryptomator/cryptofs/CryptoFileChannelWriteReadIntegrationTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/CryptoFileChannelWriteReadIntegrationTest.java
@@ -616,8 +616,8 @@ public class CryptoFileChannelWriteReadIntegrationTest {
 			Assertions.assertEquals(-1, bytesRead);
 		}
 
-		@RepeatedTest(50)
-		public void testConcurrentWriteAndTruncate() throws IOException {
+		@RepeatedTest(15)
+		public void testConcurrentWriteAndTruncate() throws IOException, InterruptedException {
 			AtomicBoolean keepWriting = new AtomicBoolean(true);
 			ByteBuffer buf = ByteBuffer.wrap("the quick brown fox jumps over the lazy dog".getBytes(StandardCharsets.UTF_8));
 			var executor = Executors.newCachedThreadPool();
@@ -632,6 +632,7 @@ public class CryptoFileChannelWriteReadIntegrationTest {
 						buf.flip();
 					}
 				});
+				Thread.sleep(1000);
 				try (FileChannel truncatingChannel = FileChannel.open(file, WRITE, TRUNCATE_EXISTING)) {
 					keepWriting.set(false);
 				}

--- a/src/test/java/org/cryptomator/cryptofs/fh/OpenCryptoFileTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/fh/OpenCryptoFileTest.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.channels.FileChannel;
 import java.nio.file.FileSystem;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFilePermissions;

--- a/src/test/java/org/cryptomator/cryptofs/fh/OpenCryptoFileTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/fh/OpenCryptoFileTest.java
@@ -94,7 +94,7 @@ public class OpenCryptoFileTest {
 
 	@Test
 	@DisplayName("Opening a file channel with TRUNCATE_EXISTING calls truncate(0) on the cleartextChannel")
-	public void testFileSizeZerodOnTruncateExisting() throws IOException {
+	public void testCleartextChannelTruncateCalledOnTruncateExisting() throws IOException {
 		EffectiveOpenOptions options = EffectiveOpenOptions.from(EnumSet.of(StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING), readonlyFlag);
 		var cleartextChannel = mock(CleartextFileChannel.class);
 		Mockito.when(headerHolder.get()).thenReturn(Mockito.mock(FileHeader.class));

--- a/src/test/java/org/cryptomator/cryptofs/fh/OpenCryptoFileTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/fh/OpenCryptoFileTest.java
@@ -47,7 +47,6 @@ public class OpenCryptoFileTest {
 	private static AtomicReference<Path> CURRENT_FILE_PATH;
 	private ReadonlyFlag readonlyFlag = mock(ReadonlyFlag.class);
 	private FileCloseListener closeListener = mock(FileCloseListener.class);
-	private ChunkCache chunkCache = mock(ChunkCache.class);
 	private Cryptor cryptor = mock(Cryptor.class);
 	private FileHeaderCryptor fileHeaderCryptor = mock(FileHeaderCryptor.class);
 	private FileHeaderHolder headerHolder = mock(FileHeaderHolder.class);
@@ -71,7 +70,7 @@ public class OpenCryptoFileTest {
 
 	@Test
 	public void testCloseTriggersCloseListener() {
-		OpenCryptoFile openCryptoFile = new OpenCryptoFile(closeListener, chunkCache, cryptor, headerHolder, chunkIO, CURRENT_FILE_PATH, fileSize, lastModified, openCryptoFileComponent);
+		OpenCryptoFile openCryptoFile = new OpenCryptoFile(closeListener, cryptor, headerHolder, chunkIO, CURRENT_FILE_PATH, fileSize, lastModified, openCryptoFileComponent);
 		openCryptoFile.close();
 		verify(closeListener).close(CURRENT_FILE_PATH.get(), openCryptoFile);
 	}
@@ -82,7 +81,7 @@ public class OpenCryptoFileTest {
 		UncheckedIOException expectedException = new UncheckedIOException(new IOException("fail!"));
 		EffectiveOpenOptions options = Mockito.mock(EffectiveOpenOptions.class);
 		Mockito.when(options.createOpenOptionsForEncryptedFile()).thenThrow(expectedException);
-		OpenCryptoFile openCryptoFile = new OpenCryptoFile(closeListener, chunkCache, cryptor, headerHolder, chunkIO, CURRENT_FILE_PATH, fileSize, lastModified, openCryptoFileComponent);
+		OpenCryptoFile openCryptoFile = new OpenCryptoFile(closeListener, cryptor, headerHolder, chunkIO, CURRENT_FILE_PATH, fileSize, lastModified, openCryptoFileComponent);
 
 		UncheckedIOException exception = Assertions.assertThrows(UncheckedIOException.class, () -> {
 			openCryptoFile.newFileChannel(options);
@@ -102,7 +101,7 @@ public class OpenCryptoFileTest {
 		Mockito.when(openCryptoFileComponent.newChannelComponent()).thenReturn(channelComponentFactory);
 		Mockito.when(channelComponentFactory.create(any(), any(), any())).thenReturn(channelComponent);
 		Mockito.when(channelComponent.channel()).thenReturn(cleartextChannel);
-		OpenCryptoFile openCryptoFile = new OpenCryptoFile(closeListener, chunkCache, cryptor, headerHolder, chunkIO, CURRENT_FILE_PATH, fileSize, lastModified, openCryptoFileComponent);
+		OpenCryptoFile openCryptoFile = new OpenCryptoFile(closeListener, cryptor, headerHolder, chunkIO, CURRENT_FILE_PATH, fileSize, lastModified, openCryptoFileComponent);
 
 		openCryptoFile.newFileChannel(options);
 		verify(cleartextChannel).truncate(0L);
@@ -114,7 +113,7 @@ public class OpenCryptoFileTest {
 
 		EffectiveOpenOptions options = Mockito.mock(EffectiveOpenOptions.class);
 		FileChannel cipherFileChannel = Mockito.mock(FileChannel.class, "cipherFilechannel");
-		OpenCryptoFile inTest = new OpenCryptoFile(closeListener, chunkCache, cryptor, headerHolder, chunkIO, CURRENT_FILE_PATH, fileSize, lastModified, openCryptoFileComponent);
+		OpenCryptoFile inTest = new OpenCryptoFile(closeListener, cryptor, headerHolder, chunkIO, CURRENT_FILE_PATH, fileSize, lastModified, openCryptoFileComponent);
 
 		@Test
 		@DisplayName("Skip file header init, if the file header already exists in memory")
@@ -198,7 +197,7 @@ public class OpenCryptoFileTest {
 		public void setup() throws IOException {
 			FS = Jimfs.newFileSystem("OpenCryptoFileTest.FileChannelFactoryTest", Configuration.unix().toBuilder().setAttributeViews("basic", "posix").build());
 			CURRENT_FILE_PATH = new AtomicReference<>(FS.getPath("currentFile"));
-			openCryptoFile = new OpenCryptoFile(closeListener, chunkCache, cryptor, headerHolder, chunkIO, CURRENT_FILE_PATH, realFileSize, lastModified, openCryptoFileComponent);
+			openCryptoFile = new OpenCryptoFile(closeListener,cryptor, headerHolder, chunkIO, CURRENT_FILE_PATH, realFileSize, lastModified, openCryptoFileComponent);
 			cleartextFileChannel = mock(CleartextFileChannel.class);
 			listener = new AtomicReference<>();
 			ciphertextChannel = new AtomicReference<>();


### PR DESCRIPTION
This PR fixes #269.

Instead of writing an "optimized", but wrong truncate block, we can simply use `CleartextChannel.truncate(0)` when opening a new file. Benefit of this method: It is already tested! And since it is synchronized and also creating a new file channel is synchronized, we can be sure that side calls cannot interfere.