### PR TITLE
Feature: More events and event refinement 

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/event/BrokenDirFileEvent.java
+++ b/src/main/java/org/cryptomator/cryptofs/event/BrokenDirFileEvent.java
@@ -1,0 +1,12 @@
+package org.cryptomator.cryptofs.event;
+
+import java.nio.file.Path;
+
+/**
+ * Emitted, if a dir.c9r file is empty or exceeds 1000 Bytes.
+ *
+ * @param ciphertextPath path to the broken dir.c9r file
+ */
+public record BrokenDirFileEvent(Path ciphertextPath) implements FilesystemEvent {
+
+}

--- a/src/main/java/org/cryptomator/cryptofs/event/BrokenFileNodeEvent.java
+++ b/src/main/java/org/cryptomator/cryptofs/event/BrokenFileNodeEvent.java
@@ -1,0 +1,15 @@
+package org.cryptomator.cryptofs.event;
+
+import java.nio.file.Path;
+
+/**
+ * Emitted, if a path within the cryptographic filesystem is accessed, but the directory representing it is missing identification files.
+ *
+ * @param cleartextPath path within the cryptographic filesystem
+ * @param ciphertextPath path of the incomplete, encrypted directory
+ *
+ * @see org.cryptomator.cryptofs.health.type.UnknownType
+ */
+public record BrokenFileNodeEvent(Path cleartextPath, Path ciphertextPath) implements FilesystemEvent {
+
+}

--- a/src/main/java/org/cryptomator/cryptofs/event/DecryptionFailedEvent.java
+++ b/src/main/java/org/cryptomator/cryptofs/event/DecryptionFailedEvent.java
@@ -10,6 +10,6 @@ import java.nio.file.Path;
  * @param ciphertextPath path to the encrypted resource
  * @param e thrown exception
  */
-public record DecryptionFailedEvent(Path ciphertextPath, AuthenticationFailedException e) implements FilesystemEvent {
+public record DecryptionFailedEvent(Path ciphertextPath, Exception e) implements FilesystemEvent {
 
 }

--- a/src/main/java/org/cryptomator/cryptofs/event/DecryptionFailedEvent.java
+++ b/src/main/java/org/cryptomator/cryptofs/event/DecryptionFailedEvent.java
@@ -1,7 +1,5 @@
 package org.cryptomator.cryptofs.event;
 
-import org.cryptomator.cryptolib.api.AuthenticationFailedException;
-
 import java.nio.file.Path;
 
 /**
@@ -11,5 +9,4 @@ import java.nio.file.Path;
  * @param e thrown exception
  */
 public record DecryptionFailedEvent(Path ciphertextPath, Exception e) implements FilesystemEvent {
-
 }

--- a/src/main/java/org/cryptomator/cryptofs/event/FilesystemEvent.java
+++ b/src/main/java/org/cryptomator/cryptofs/event/FilesystemEvent.java
@@ -22,6 +22,6 @@ import java.util.function.Consumer;
  *
  * @apiNote Events might have occured a long time ago in a galaxy far, far away... therefore, any feedback method is non-blocking and might fail due to changes in the filesystem.
  */
-public sealed interface FilesystemEvent permits ConflictResolutionFailedEvent, ConflictResolvedEvent, DecryptionFailedEvent, BrokenDirFileEvent {
+public sealed interface FilesystemEvent permits BrokenDirFileEvent, BrokenFileNodeEvent, ConflictResolutionFailedEvent, ConflictResolvedEvent, DecryptionFailedEvent {
 
 }

--- a/src/main/java/org/cryptomator/cryptofs/event/FilesystemEvent.java
+++ b/src/main/java/org/cryptomator/cryptofs/event/FilesystemEvent.java
@@ -22,6 +22,6 @@ import java.util.function.Consumer;
  *
  * @apiNote Events might have occured a long time ago in a galaxy far, far away... therefore, any feedback method is non-blocking and might fail due to changes in the filesystem.
  */
-public sealed interface FilesystemEvent permits ConflictResolutionFailedEvent, ConflictResolvedEvent, DecryptionFailedEvent {
+public sealed interface FilesystemEvent permits ConflictResolutionFailedEvent, ConflictResolvedEvent, DecryptionFailedEvent, BrokenDirFileEvent {
 
 }

--- a/src/main/java/org/cryptomator/cryptofs/fh/FileHeaderHolder.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/FileHeaderHolder.java
@@ -2,7 +2,6 @@ package org.cryptomator.cryptofs.fh;
 
 import org.cryptomator.cryptofs.event.DecryptionFailedEvent;
 import org.cryptomator.cryptofs.event.FilesystemEvent;
-import org.cryptomator.cryptolib.api.AuthenticationFailedException;
 import org.cryptomator.cryptolib.api.CryptoException;
 import org.cryptomator.cryptolib.api.Cryptor;
 import org.cryptomator.cryptolib.api.FileHeader;
@@ -81,9 +80,7 @@ public class FileHeaderHolder {
 			isPersisted.set(true);
 			return existingHeader;
 		} catch (IllegalArgumentException | CryptoException e) {
-			if (e instanceof AuthenticationFailedException afe) {
-				eventConsumer.accept(new DecryptionFailedEvent(path.get(), afe));
-			}
+			eventConsumer.accept(new DecryptionFailedEvent(path.get(), e));
 			throw new IOException("Unable to decrypt header of file " + path.get(), e);
 		}
 	}

--- a/src/test/java/org/cryptomator/cryptofs/CryptoPathMapperTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/CryptoPathMapperTest.java
@@ -10,6 +10,7 @@ package org.cryptomator.cryptofs;
 
 import com.google.common.base.Strings;
 import org.cryptomator.cryptofs.common.CiphertextFileType;
+import org.cryptomator.cryptofs.event.FilesystemEvent;
 import org.cryptomator.cryptolib.api.Cryptor;
 import org.cryptomator.cryptolib.api.FileNameCryptor;
 import org.junit.jupiter.api.Assertions;
@@ -27,8 +28,11 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.spi.FileSystemProvider;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import static org.mockito.Mockito.mock;
 
 public class CryptoPathMapperTest {
 
@@ -41,6 +45,7 @@ public class CryptoPathMapperTest {
 	private final VaultConfig vaultConfig = Mockito.mock(VaultConfig.class);
 	private final Symlinks symlinks = Mockito.mock(Symlinks.class);
 	private final CryptoFileSystemImpl fileSystem = Mockito.mock(CryptoFileSystemImpl.class);
+	private final Consumer<FilesystemEvent> eventConsumer = mock(Consumer.class);
 
 	@BeforeEach
 	public void setup() {
@@ -74,7 +79,7 @@ public class CryptoPathMapperTest {
 		Path d0000 = Mockito.mock(Path.class);
 		Mockito.when(d00.resolve("00")).thenReturn(d0000);
 
-		CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig);
+		CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig, eventConsumer);
 		Path path = mapper.getCiphertextDir(fileSystem.getRootPath()).path();
 		Assertions.assertEquals(d0000, path);
 	}
@@ -98,7 +103,7 @@ public class CryptoPathMapperTest {
 		Path d0001 = Mockito.mock(Path.class);
 		Mockito.when(d00.resolve("01")).thenReturn(d0001);
 
-		CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig);
+		CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig, eventConsumer);
 		Path path = mapper.getCiphertextDir(fileSystem.getPath("/foo")).path();
 		Assertions.assertEquals(d0001, path);
 	}
@@ -132,7 +137,7 @@ public class CryptoPathMapperTest {
 		Path d0002 = Mockito.mock(Path.class);
 		Mockito.when(d00.resolve("02")).thenReturn(d0002);
 
-		CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig);
+		CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig, eventConsumer);
 		Path path = mapper.getCiphertextDir(fileSystem.getPath("/foo/bar")).path();
 		Assertions.assertEquals(d0002, path);
 	}
@@ -170,7 +175,7 @@ public class CryptoPathMapperTest {
 
 		var testPath = "/" + IntStream.range(0, maxNestingDepth).mapToObj("%02d"::formatted).collect(Collectors.joining("/")) + "/cleartextFile";
 
-		CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig);
+		CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig, eventConsumer);
 		Path path = mapper.getCiphertextFilePath(fileSystem.getPath(testPath)).getRawPath();
 		Assertions.assertEquals(finalEncryptedFile, path);
 	}
@@ -207,7 +212,7 @@ public class CryptoPathMapperTest {
 		Mockito.when(d0002.resolve("zab.c9r")).thenReturn(d0002zab);
 		Mockito.when(fileNameCryptor.encryptFilename(Mockito.any(), Mockito.eq("baz"), Mockito.any())).thenReturn("zab");
 
-		CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig);
+		CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig, eventConsumer);
 		Path path = mapper.getCiphertextFilePath(fileSystem.getPath("/foo/bar/baz")).getRawPath();
 		Assertions.assertEquals(d0002zab, path);
 	}
@@ -255,7 +260,7 @@ public class CryptoPathMapperTest {
 
 		@Test
 		public void testGetCiphertextFileTypeOfRootPath() throws IOException {
-			CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig);
+			CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig, eventConsumer);
 			CiphertextFileType type = mapper.getCiphertextFileType(fileSystem.getRootPath());
 			Assertions.assertEquals(CiphertextFileType.DIRECTORY, type);
 		}
@@ -264,7 +269,7 @@ public class CryptoPathMapperTest {
 		public void testGetCiphertextFileTypeForNonexistingFile() throws IOException {
 			Mockito.when(underlyingFileSystemProvider.readAttributes(c9rPath, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS)).thenThrow(NoSuchFileException.class);
 
-			CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig);
+			CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig, eventConsumer);
 
 			CryptoPath path = fileSystem.getPath("/CLEAR");
 			Assertions.assertThrows(NoSuchFileException.class, () -> {
@@ -277,7 +282,7 @@ public class CryptoPathMapperTest {
 			Mockito.when(underlyingFileSystemProvider.readAttributes(c9rPath, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS)).thenReturn(c9rAttrs);
 			Mockito.when(c9rAttrs.isDirectory()).thenReturn(false);
 
-			CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig);
+			CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig, eventConsumer);
 
 			CryptoPath path = fileSystem.getPath("/CLEAR");
 			CiphertextFileType type = mapper.getCiphertextFileType(path);
@@ -293,7 +298,7 @@ public class CryptoPathMapperTest {
 			Mockito.when(underlyingFileSystemProvider.readAttributes(contentsFilePath, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS)).thenThrow(NoSuchFileException.class);
 			Mockito.when(underlyingFileSystemProvider.exists(dirFilePath, LinkOption.NOFOLLOW_LINKS)).thenReturn(true);
 
-			CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig);
+			CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig, eventConsumer);
 
 			CryptoPath path = fileSystem.getPath("/CLEAR");
 			CiphertextFileType type = mapper.getCiphertextFileType(path);
@@ -309,7 +314,7 @@ public class CryptoPathMapperTest {
 			Mockito.when(underlyingFileSystemProvider.readAttributes(contentsFilePath, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS)).thenThrow(NoSuchFileException.class);
 			Mockito.when(underlyingFileSystemProvider.exists(symlinkFilePath, LinkOption.NOFOLLOW_LINKS)).thenReturn(true);
 
-			CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig);
+			CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig, eventConsumer);
 
 			CryptoPath path = fileSystem.getPath("/CLEAR");
 			CiphertextFileType type = mapper.getCiphertextFileType(path);
@@ -327,12 +332,14 @@ public class CryptoPathMapperTest {
 			Mockito.when(longFileNameProvider.deflate(Mockito.any())).thenReturn(new LongFileNameProvider.DeflatedFileName(c9rPath, null, null));
 			Mockito.when(underlyingFileSystemProvider.exists(contentsFilePath, LinkOption.NOFOLLOW_LINKS)).thenReturn(true);
 
-			CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig);
+			CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig, eventConsumer);
 
 			CryptoPath path = fileSystem.getPath("/LONGCLEAR");
 			CiphertextFileType type = mapper.getCiphertextFileType(path);
 			Assertions.assertEquals(CiphertextFileType.FILE, type);
 		}
+
+		//TODO: Tests for determining filetype order and failure including event emit
 
 	}
 
@@ -386,7 +393,7 @@ public class CryptoPathMapperTest {
 		@Test
 		@DisplayName("Invalidating node causes cache miss on next retrieval")
 		public void testRemovedEntryMiss() throws IOException {
-			CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig);
+			CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig, eventConsumer);
 			var fooPath = fileSystem.getPath("/foo");
 			mapper.getCiphertextDir(fooPath);
 			mapper.invalidatePathMapping(fooPath);
@@ -401,7 +408,7 @@ public class CryptoPathMapperTest {
 			var fooPath = fileSystem.getPath("/foo");
 			var fooBarPath = fileSystem.getPath("/foo/bar");
 
-			CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig);
+			CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig, eventConsumer);
 			mapper.getCiphertextDir(fooPath);
 			mapper.getCiphertextDir(fooBarPath);
 			mapper.invalidatePathMapping(fooPath);
@@ -417,7 +424,7 @@ public class CryptoPathMapperTest {
 			var fooPath = fileSystem.getPath("/foo");
 			var kikPath = fileSystem.getPath("/kik");
 
-			CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig);
+			CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig, eventConsumer);
 			mapper.getCiphertextDir(fooPath);
 			mapper.movePathMapping(fooPath, kikPath);
 			var mapperSpy = Mockito.spy(mapper);
@@ -433,7 +440,7 @@ public class CryptoPathMapperTest {
 			var fooBarPath = fileSystem.getPath("/foo/bar");
 			var kikPath = fileSystem.getPath("/kik");
 
-			CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig);
+			CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig, eventConsumer);
 			mapper.getCiphertextDir(fooPath);
 			mapper.getCiphertextDir(fooBarPath);
 			mapper.movePathMapping(fooPath, kikPath);

--- a/src/test/java/org/cryptomator/cryptofs/DirectoryIdLoaderTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/DirectoryIdLoaderTest.java
@@ -1,26 +1,32 @@
 package org.cryptomator.cryptofs;
 
+import org.cryptomator.cryptofs.event.BrokenDirFileEvent;
+import org.cryptomator.cryptofs.event.FilesystemEvent;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.FileSystem;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.spi.FileSystemProvider;
+import java.util.function.Consumer;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class DirectoryIdLoaderTest {
@@ -29,14 +35,16 @@ public class DirectoryIdLoaderTest {
 	private final FileSystem fileSystem = mock(FileSystem.class);
 	private final Path dirFilePath = mock(Path.class);
 	private final Path otherDirFilePath = mock(Path.class);
+	private final Consumer<FilesystemEvent> eventConsumer = mock(Consumer.class);
 
-	private final DirectoryIdLoader inTest = new DirectoryIdLoader();
+	private final DirectoryIdLoader inTest = new DirectoryIdLoader(eventConsumer);
 
 	@BeforeEach
 	public void setup() {
 		when(dirFilePath.getFileSystem()).thenReturn(fileSystem);
 		when(otherDirFilePath.getFileSystem()).thenReturn(fileSystem);
 		when(fileSystem.provider()).thenReturn(provider);
+		doNothing().when(eventConsumer).accept(any());
 	}
 
 	@Test
@@ -88,6 +96,8 @@ public class DirectoryIdLoaderTest {
 			inTest.load(dirFilePath);
 		});
 		MatcherAssert.assertThat(ioException.getMessage(), containsString("Invalid, empty directory file"));
+		var isBrokenDirFileEvent = (ArgumentMatcher<FilesystemEvent>) ev -> ev instanceof BrokenDirFileEvent;
+		verify(eventConsumer).accept(ArgumentMatchers.argThat(isBrokenDirFileEvent));
 	}
 
 	@Test
@@ -100,6 +110,8 @@ public class DirectoryIdLoaderTest {
 			inTest.load(dirFilePath);
 		});
 		MatcherAssert.assertThat(ioException.getMessage(), containsString("Unexpectedly large directory file"));
+		var isBrokenDirFileEvent = (ArgumentMatcher<FilesystemEvent>) ev -> ev instanceof BrokenDirFileEvent;
+		verify(eventConsumer).accept(ArgumentMatchers.argThat(isBrokenDirFileEvent));
 	}
 
 }


### PR DESCRIPTION
This PR adds mainly to new [events](https://github.com/cryptomator/cryptofs/pull/277):

* BrokenDirFileEvent: If the directory link file (dir.c9r) is empty or obese, thus breaking cleartext paths
* BrokenFileNodeEvent: If a c9r directory does not contain any identification file