### PR TITLE
Fix: Custom filesystem exception for invalid ciphertext nodes

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/CryptoPathMapper.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoPathMapper.java
@@ -105,7 +105,7 @@ public class CryptoPathMapper {
 				} else {
 					eventConsumer.accept(new BrokenFileNodeEvent(cleartextPath, ciphertextPath.getRawPath()));
 					LOG.warn("Did not find valid content inside of {}", ciphertextPath.getRawPath());
-					throw new NoSuchFileException(cleartextPath.toString(), null, "Could not determine type of file " + ciphertextPath.getRawPath());
+					throw new InvalidFileNodeException(cleartextPath.toString(), ciphertextPath.getRawPath().toString());
 				}
 			} else {
 				// assume "file" if not a directory (even if it isn't a "regular" file, see issue #81):
@@ -117,7 +117,7 @@ public class CryptoPathMapper {
 	public CiphertextFilePath getCiphertextFilePath(CryptoPath cleartextPath) throws IOException {
 		CryptoPath parentPath = cleartextPath.getParent();
 		if (parentPath == null) {
-			throw new IllegalArgumentException("Invalid file path (must have a parent): " + cleartextPath); //TODO: cleartext path in Logs!
+			throw new IllegalArgumentException("Invalid file path (must have a parent): " + cleartextPath);
 		}
 		CiphertextDirectory parent = getCiphertextDir(parentPath);
 		String cleartextName = cleartextPath.getFileName().toString();

--- a/src/main/java/org/cryptomator/cryptofs/InvalidFileNodeException.java
+++ b/src/main/java/org/cryptomator/cryptofs/InvalidFileNodeException.java
@@ -1,0 +1,13 @@
+package org.cryptomator.cryptofs;
+
+import java.nio.file.FileSystemException;
+
+/**
+ * Exception thrown if a c9s or c9r directory does not contain any identification files
+ */
+public class InvalidFileNodeException extends FileSystemException {
+
+	public InvalidFileNodeException(String cleartext, String ciphertext) {
+		super(cleartext, null, "Unknown type of node %s: Missing identification file".formatted(ciphertext));
+	}
+}

--- a/src/test/java/org/cryptomator/cryptofs/CryptoPathMapperTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/CryptoPathMapperTest.java
@@ -390,7 +390,7 @@ public class CryptoPathMapperTest {
 		}
 
 		@Test
-		@DisplayName("Throw NoSuchFileException if no known file exists")
+		@DisplayName("Throw a FileSystemException if no id file exists")
 		public void testNoKnownFileExists() throws IOException {
 			Mockito.when(underlyingFileSystemProvider.readAttributes(c9rPath, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS)).thenReturn(c9rAttrs);
 			Mockito.when(c9rAttrs.isDirectory()).thenReturn(true);
@@ -404,7 +404,7 @@ public class CryptoPathMapperTest {
 			CryptoPathMapper mapper = new CryptoPathMapper(pathToVault, cryptor, dirIdProvider, longFileNameProvider, vaultConfig, eventConsumer);
 
 			CryptoPath path = fileSystem.getPath("/CLEAR");
-			Assertions.assertThrows(NoSuchFileException.class, () -> mapper.getCiphertextFileType(path));
+			Assertions.assertThrows(InvalidFileNodeException.class, () -> mapper.getCiphertextFileType(path));
 			var isBrokenFileNodeEvent = (ArgumentMatcher<FilesystemEvent>) ev -> ev instanceof BrokenFileNodeEvent;
 			verify(eventConsumer).accept(ArgumentMatchers.argThat(isBrokenFileNodeEvent));
 		}


### PR DESCRIPTION
This PR changes an error behavior of the filesystem.

On the encrypted/ciphertext side, Cryptofs can represent decrypted/cleartext filenodes either as single files or directories. In the latter case the directory must contain any identification files in order to be recognized. (dir.c9r, symlink.c9r, etc)

In the current version, if such a file was not present, a `NoSuchFileException`  is thrown. But this exception does not represent the actual state of the filesystem node: Instead of not being present, it is broken. And with the wrong exception library consumer might be tempted to use the "free" path, albeit it is not, only running into the next exception.

I replaced the wrong exception with a new, custom `FileSystemException`: InvalidFileNodeException. The consumer does not know about it and recieves ultimately a generic IOException, indicating there is something wrong with the filesystem node.