### PR TITLE
Feature: Dagger 2.55

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<!-- dependencies -->
 		<cryptolib.version>2.2.0</cryptolib.version>
 		<jwt.version>4.5.0</jwt.version>
-		<dagger.version>2.51.1</dagger.version>
+		<dagger.version>2.55</dagger.version>
 		<guava.version>33.4.0-jre</guava.version>
 		<caffeine.version>3.2.0</caffeine.version>
 		<slf4j.version>2.0.17</slf4j.version>
@@ -90,6 +90,11 @@
 			<groupId>com.google.dagger</groupId>
 			<artifactId>dagger</artifactId>
 			<version>${dagger.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.inject</groupId>
+			<artifactId>jakarta.inject-api</artifactId>
+			<version>2.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,7 @@
 							<version>${jmh.version}</version>
 						</path>
 					</annotationProcessorPaths>
+					<compilerArgs>-Adagger.useBindingGraphFix=ENABLED</compilerArgs>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -19,6 +19,7 @@ module org.cryptomator.cryptofs {
 	// https://github.com/javax-inject/javax-inject/issues/33
 	// May be provided by another lib during runtime
 	requires static javax.inject;
+	requires jakarta.inject;
 	requires java.compiler;
 
 	exports org.cryptomator.cryptofs;

--- a/src/main/java/org/cryptomator/cryptofs/CopyOperation.java
+++ b/src/main/java/org/cryptomator/cryptofs/CopyOperation.java
@@ -2,8 +2,8 @@ package org.cryptomator.cryptofs;
 
 import org.cryptomator.cryptofs.common.ArrayUtils;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.file.CopyOption;

--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileStore.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileStore.java
@@ -10,7 +10,7 @@ package org.cryptomator.cryptofs;
 
 import org.cryptomator.cryptofs.attr.AttributeViewType;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.file.FileStore;
 import java.nio.file.attribute.FileAttributeView;

--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemImpl.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemImpl.java
@@ -22,7 +22,7 @@ import org.cryptomator.cryptofs.dir.DirectoryStreamFilters;
 import org.cryptomator.cryptofs.fh.OpenCryptoFiles;
 import org.cryptomator.cryptolib.api.Cryptor;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.file.AccessDeniedException;

--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemProviderComponent.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemProviderComponent.java
@@ -3,7 +3,7 @@ package org.cryptomator.cryptofs;
 import dagger.BindsInstance;
 import dagger.Component;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 import java.security.SecureRandom;
 
 @Singleton

--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemScoped.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemScoped.java
@@ -5,7 +5,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 
-import javax.inject.Scope;
+import jakarta.inject.Scope;
 
 @Scope
 @Documented

--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemStats.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystemStats.java
@@ -4,7 +4,7 @@ import static java.lang.Math.max;
 
 import java.util.concurrent.atomic.LongAdder;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 /**
  * Provides access to file system performance metrics.

--- a/src/main/java/org/cryptomator/cryptofs/CryptoFileSystems.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoFileSystems.java
@@ -9,8 +9,8 @@ import org.cryptomator.cryptolib.api.MasterkeyLoadingFailedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystemAlreadyExistsException;

--- a/src/main/java/org/cryptomator/cryptofs/CryptoPathFactory.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoPathFactory.java
@@ -2,7 +2,7 @@ package org.cryptomator.cryptofs;
 
 import com.google.common.base.Splitter;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.text.Normalizer;
 import java.util.Collections;
 import java.util.stream.Stream;

--- a/src/main/java/org/cryptomator/cryptofs/CryptoPathMapper.java
+++ b/src/main/java/org/cryptomator/cryptofs/CryptoPathMapper.java
@@ -19,7 +19,7 @@ import org.cryptomator.cryptolib.api.Cryptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;

--- a/src/main/java/org/cryptomator/cryptofs/DirectoryIdBackup.java
+++ b/src/main/java/org/cryptomator/cryptofs/DirectoryIdBackup.java
@@ -6,7 +6,7 @@ import org.cryptomator.cryptolib.api.Cryptor;
 import org.cryptomator.cryptolib.common.DecryptingReadableByteChannel;
 import org.cryptomator.cryptolib.common.EncryptingWritableByteChannel;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;

--- a/src/main/java/org/cryptomator/cryptofs/DirectoryIdLoader.java
+++ b/src/main/java/org/cryptomator/cryptofs/DirectoryIdLoader.java
@@ -4,7 +4,7 @@ import com.github.benmanes.caffeine.cache.CacheLoader;
 import org.cryptomator.cryptofs.event.BrokenDirFileEvent;
 import org.cryptomator.cryptofs.event.FilesystemEvent;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.channels.Channels;

--- a/src/main/java/org/cryptomator/cryptofs/DirectoryIdProvider.java
+++ b/src/main/java/org/cryptomator/cryptofs/DirectoryIdProvider.java
@@ -14,7 +14,7 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;

--- a/src/main/java/org/cryptomator/cryptofs/FileNameDecryptor.java
+++ b/src/main/java/org/cryptomator/cryptofs/FileNameDecryptor.java
@@ -8,7 +8,7 @@ import org.cryptomator.cryptolib.api.CryptoException;
 import org.cryptomator.cryptolib.api.Cryptor;
 import org.cryptomator.cryptolib.api.FileNameCryptor;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.file.FileSystemException;
 import java.nio.file.NoSuchFileException;

--- a/src/main/java/org/cryptomator/cryptofs/GlobToRegexConverter.java
+++ b/src/main/java/org/cryptomator/cryptofs/GlobToRegexConverter.java
@@ -1,7 +1,7 @@
 package org.cryptomator.cryptofs;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 
 import static org.cryptomator.cryptofs.common.Constants.SEPARATOR;
 

--- a/src/main/java/org/cryptomator/cryptofs/LongFileNameProvider.java
+++ b/src/main/java/org/cryptomator/cryptofs/LongFileNameProvider.java
@@ -14,7 +14,7 @@ import com.google.common.base.Throwables;
 import com.google.common.io.BaseEncoding;
 import org.cryptomator.cryptolib.common.MessageDigestSupplier;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;

--- a/src/main/java/org/cryptomator/cryptofs/MoveOperation.java
+++ b/src/main/java/org/cryptomator/cryptofs/MoveOperation.java
@@ -2,8 +2,8 @@ package org.cryptomator.cryptofs;
 
 import org.cryptomator.cryptofs.common.ArrayUtils;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import java.io.IOException;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.CopyOption;

--- a/src/main/java/org/cryptomator/cryptofs/PathMatcherFactory.java
+++ b/src/main/java/org/cryptomator/cryptofs/PathMatcherFactory.java
@@ -1,7 +1,7 @@
 package org.cryptomator.cryptofs;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import java.nio.file.PathMatcher;
 import java.util.regex.Pattern;
 

--- a/src/main/java/org/cryptomator/cryptofs/PathToVault.java
+++ b/src/main/java/org/cryptomator/cryptofs/PathToVault.java
@@ -5,7 +5,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 
-import javax.inject.Qualifier;
+import jakarta.inject.Qualifier;
 
 @Qualifier
 @Documented

--- a/src/main/java/org/cryptomator/cryptofs/ReadonlyFlag.java
+++ b/src/main/java/org/cryptomator/cryptofs/ReadonlyFlag.java
@@ -3,7 +3,7 @@ package org.cryptomator.cryptofs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.nio.file.ReadOnlyFileSystemException;
 
 @CryptoFileSystemScoped

--- a/src/main/java/org/cryptomator/cryptofs/Symlinks.java
+++ b/src/main/java/org/cryptomator/cryptofs/Symlinks.java
@@ -4,7 +4,7 @@ import org.cryptomator.cryptofs.common.CiphertextFileType;
 import org.cryptomator.cryptofs.common.Constants;
 import org.cryptomator.cryptofs.fh.OpenCryptoFiles;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;

--- a/src/main/java/org/cryptomator/cryptofs/attr/AttributeByNameProvider.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/AttributeByNameProvider.java
@@ -12,7 +12,7 @@ import com.google.common.collect.ImmutableSortedMap;
 import org.cryptomator.cryptofs.CryptoFileSystemScoped;
 import org.cryptomator.cryptofs.CryptoPath;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.file.LinkOption;
 import java.nio.file.attribute.BasicFileAttributeView;

--- a/src/main/java/org/cryptomator/cryptofs/attr/AttributeComponent.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/AttributeComponent.java
@@ -4,7 +4,7 @@ import dagger.BindsInstance;
 import dagger.Subcomponent;
 import org.cryptomator.cryptofs.common.CiphertextFileType;
 
-import javax.inject.Named;
+import jakarta.inject.Named;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 

--- a/src/main/java/org/cryptomator/cryptofs/attr/AttributeModule.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/AttributeModule.java
@@ -8,7 +8,7 @@ import org.cryptomator.cryptofs.fh.OpenCryptoFile;
 import org.cryptomator.cryptofs.fh.OpenCryptoFiles;
 import org.cryptomator.cryptolib.api.Cryptor;
 
-import javax.inject.Named;
+import jakarta.inject.Named;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.DosFileAttributes;

--- a/src/main/java/org/cryptomator/cryptofs/attr/AttributeProvider.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/AttributeProvider.java
@@ -15,7 +15,7 @@ import org.cryptomator.cryptofs.Symlinks;
 import org.cryptomator.cryptofs.common.ArrayUtils;
 import org.cryptomator.cryptofs.common.CiphertextFileType;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;

--- a/src/main/java/org/cryptomator/cryptofs/attr/AttributeScoped.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/AttributeScoped.java
@@ -1,6 +1,6 @@
 package org.cryptomator.cryptofs.attr;
 
-import javax.inject.Scope;
+import jakarta.inject.Scope;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;

--- a/src/main/java/org/cryptomator/cryptofs/attr/AttributeViewModule.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/AttributeViewModule.java
@@ -44,12 +44,12 @@ abstract class AttributeViewModule {
 
 	@Provides
 	@AttributeViewScoped
-	public static Optional<FileAttributeView> provideAttributeView(Map<Class<?>, Provider<FileAttributeView>> providers, Class<? extends FileAttributeView> requestedType) {
-		Provider<FileAttributeView> provider = providers.get(requestedType);
-		if (provider == null) {
+	public static Optional<FileAttributeView> provideAttributeView(Map<Class<?>, FileAttributeView> providers, Class<? extends FileAttributeView> requestedType) {
+		var view = providers.get(requestedType);
+		if (view == null) {
 			return Optional.empty();
 		} else {
-			return Optional.of(provider.get());
+			return Optional.of(view);
 		}
 	}
 

--- a/src/main/java/org/cryptomator/cryptofs/attr/AttributeViewModule.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/AttributeViewModule.java
@@ -6,7 +6,7 @@ import dagger.Provides;
 import dagger.multibindings.ClassKey;
 import dagger.multibindings.IntoMap;
 
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.DosFileAttributeView;
 import java.nio.file.attribute.FileAttributeView;

--- a/src/main/java/org/cryptomator/cryptofs/attr/AttributeViewProvider.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/AttributeViewProvider.java
@@ -13,7 +13,7 @@ import org.cryptomator.cryptofs.CryptoPath;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.attribute.FileAttributeView;

--- a/src/main/java/org/cryptomator/cryptofs/attr/AttributeViewScoped.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/AttributeViewScoped.java
@@ -1,6 +1,6 @@
 package org.cryptomator.cryptofs.attr;
 
-import javax.inject.Scope;
+import jakarta.inject.Scope;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;

--- a/src/main/java/org/cryptomator/cryptofs/attr/CryptoBasicFileAttributeView.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/CryptoBasicFileAttributeView.java
@@ -14,7 +14,7 @@ import org.cryptomator.cryptofs.ReadonlyFlag;
 import org.cryptomator.cryptofs.Symlinks;
 import org.cryptomator.cryptofs.fh.OpenCryptoFiles;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.file.LinkOption;
 import java.nio.file.attribute.BasicFileAttributeView;

--- a/src/main/java/org/cryptomator/cryptofs/attr/CryptoDosFileAttributeView.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/CryptoDosFileAttributeView.java
@@ -14,7 +14,7 @@ import org.cryptomator.cryptofs.ReadonlyFlag;
 import org.cryptomator.cryptofs.Symlinks;
 import org.cryptomator.cryptofs.fh.OpenCryptoFiles;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.file.LinkOption;
 import java.nio.file.attribute.DosFileAttributeView;

--- a/src/main/java/org/cryptomator/cryptofs/attr/CryptoFileOwnerAttributeView.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/CryptoFileOwnerAttributeView.java
@@ -14,7 +14,7 @@ import org.cryptomator.cryptofs.ReadonlyFlag;
 import org.cryptomator.cryptofs.Symlinks;
 import org.cryptomator.cryptofs.fh.OpenCryptoFiles;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.file.LinkOption;
 import java.nio.file.attribute.FileOwnerAttributeView;

--- a/src/main/java/org/cryptomator/cryptofs/attr/CryptoPosixFileAttributeView.java
+++ b/src/main/java/org/cryptomator/cryptofs/attr/CryptoPosixFileAttributeView.java
@@ -14,7 +14,7 @@ import org.cryptomator.cryptofs.ReadonlyFlag;
 import org.cryptomator.cryptofs.Symlinks;
 import org.cryptomator.cryptofs.fh.OpenCryptoFiles;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.file.LinkOption;
 import java.nio.file.attribute.GroupPrincipal;

--- a/src/main/java/org/cryptomator/cryptofs/ch/ChannelScoped.java
+++ b/src/main/java/org/cryptomator/cryptofs/ch/ChannelScoped.java
@@ -1,6 +1,6 @@
 package org.cryptomator.cryptofs.ch;
 
-import javax.inject.Scope;
+import jakarta.inject.Scope;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 

--- a/src/main/java/org/cryptomator/cryptofs/ch/CleartextFileChannel.java
+++ b/src/main/java/org/cryptomator/cryptofs/ch/CleartextFileChannel.java
@@ -16,7 +16,7 @@ import org.cryptomator.cryptolib.api.Cryptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;

--- a/src/main/java/org/cryptomator/cryptofs/common/FinallyUtil.java
+++ b/src/main/java/org/cryptomator/cryptofs/common/FinallyUtil.java
@@ -1,7 +1,7 @@
 package org.cryptomator.cryptofs.common;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.stream.Stream;

--- a/src/main/java/org/cryptomator/cryptofs/dir/BrokenDirectoryFilter.java
+++ b/src/main/java/org/cryptomator/cryptofs/dir/BrokenDirectoryFilter.java
@@ -5,7 +5,7 @@ import org.cryptomator.cryptofs.common.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/src/main/java/org/cryptomator/cryptofs/dir/C9rConflictResolver.java
+++ b/src/main/java/org/cryptomator/cryptofs/dir/C9rConflictResolver.java
@@ -13,8 +13,8 @@ import org.cryptomator.cryptolib.api.Cryptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
-import javax.inject.Named;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;

--- a/src/main/java/org/cryptomator/cryptofs/dir/C9rDecryptor.java
+++ b/src/main/java/org/cryptomator/cryptofs/dir/C9rDecryptor.java
@@ -7,8 +7,8 @@ import org.cryptomator.cryptofs.common.StringUtils;
 import org.cryptomator.cryptolib.api.AuthenticationFailedException;
 import org.cryptomator.cryptolib.api.Cryptor;
 
-import javax.inject.Inject;
-import javax.inject.Named;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.regex.MatchResult;

--- a/src/main/java/org/cryptomator/cryptofs/dir/C9rProcessor.java
+++ b/src/main/java/org/cryptomator/cryptofs/dir/C9rProcessor.java
@@ -2,7 +2,7 @@ package org.cryptomator.cryptofs.dir;
 
 import org.cryptomator.cryptofs.common.Constants;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.util.stream.Stream;
 
 @DirectoryStreamScoped

--- a/src/main/java/org/cryptomator/cryptofs/dir/C9sInflator.java
+++ b/src/main/java/org/cryptomator/cryptofs/dir/C9sInflator.java
@@ -9,8 +9,8 @@ import org.cryptomator.cryptolib.api.Cryptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
-import javax.inject.Named;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;

--- a/src/main/java/org/cryptomator/cryptofs/dir/C9sProcessor.java
+++ b/src/main/java/org/cryptomator/cryptofs/dir/C9sProcessor.java
@@ -2,7 +2,7 @@ package org.cryptomator.cryptofs.dir;
 
 import org.cryptomator.cryptofs.common.Constants;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.util.stream.Stream;
 
 @DirectoryStreamScoped

--- a/src/main/java/org/cryptomator/cryptofs/dir/CiphertextDirectoryDeleter.java
+++ b/src/main/java/org/cryptomator/cryptofs/dir/CiphertextDirectoryDeleter.java
@@ -4,7 +4,7 @@ import org.cryptomator.cryptofs.CryptoFileSystemScoped;
 import org.cryptomator.cryptofs.CryptoPath;
 import org.cryptomator.cryptofs.common.DeletingFileVisitor;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.DirectoryStream;

--- a/src/main/java/org/cryptomator/cryptofs/dir/CryptoDirectoryStream.java
+++ b/src/main/java/org/cryptomator/cryptofs/dir/CryptoDirectoryStream.java
@@ -11,8 +11,8 @@ package org.cryptomator.cryptofs.dir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
-import javax.inject.Named;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import java.io.IOException;
 import java.nio.file.DirectoryIteratorException;
 import java.nio.file.DirectoryStream;

--- a/src/main/java/org/cryptomator/cryptofs/dir/DirectoryStreamComponent.java
+++ b/src/main/java/org/cryptomator/cryptofs/dir/DirectoryStreamComponent.java
@@ -3,7 +3,7 @@ package org.cryptomator.cryptofs.dir;
 import dagger.BindsInstance;
 import dagger.Subcomponent;
 
-import javax.inject.Named;
+import jakarta.inject.Named;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Path;
 import java.util.function.Consumer;

--- a/src/main/java/org/cryptomator/cryptofs/dir/DirectoryStreamFactory.java
+++ b/src/main/java/org/cryptomator/cryptofs/dir/DirectoryStreamFactory.java
@@ -6,7 +6,7 @@ import org.cryptomator.cryptofs.CryptoPath;
 import org.cryptomator.cryptofs.CryptoPathMapper;
 import org.cryptomator.cryptofs.common.Constants;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.file.ClosedFileSystemException;
 import java.nio.file.DirectoryStream;

--- a/src/main/java/org/cryptomator/cryptofs/dir/DirectoryStreamScoped.java
+++ b/src/main/java/org/cryptomator/cryptofs/dir/DirectoryStreamScoped.java
@@ -1,6 +1,6 @@
 package org.cryptomator.cryptofs.dir;
 
-import javax.inject.Scope;
+import jakarta.inject.Scope;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 

--- a/src/main/java/org/cryptomator/cryptofs/dir/NodeProcessor.java
+++ b/src/main/java/org/cryptomator/cryptofs/dir/NodeProcessor.java
@@ -2,7 +2,7 @@ package org.cryptomator.cryptofs.dir;
 
 import org.cryptomator.cryptofs.common.Constants;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.util.stream.Stream;
 
 @DirectoryStreamScoped

--- a/src/main/java/org/cryptomator/cryptofs/fh/BufferPool.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/BufferPool.java
@@ -3,7 +3,7 @@ package org.cryptomator.cryptofs.fh;
 import org.cryptomator.cryptofs.CryptoFileSystemScoped;
 import org.cryptomator.cryptolib.api.Cryptor;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.util.Optional;

--- a/src/main/java/org/cryptomator/cryptofs/fh/ChunkCache.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/ChunkCache.java
@@ -7,7 +7,7 @@ import com.google.common.base.Preconditions;
 import org.cryptomator.cryptofs.CryptoFileSystemStats;
 import org.cryptomator.cryptolib.api.AuthenticationFailedException;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;

--- a/src/main/java/org/cryptomator/cryptofs/fh/ChunkIO.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/ChunkIO.java
@@ -1,6 +1,6 @@
 package org.cryptomator.cryptofs.fh;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;

--- a/src/main/java/org/cryptomator/cryptofs/fh/ChunkLoader.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/ChunkLoader.java
@@ -6,8 +6,8 @@ import org.cryptomator.cryptofs.event.FilesystemEvent;
 import org.cryptomator.cryptolib.api.AuthenticationFailedException;
 import org.cryptomator.cryptolib.api.Cryptor;
 
-import javax.inject.Inject;
-import javax.inject.Named;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;

--- a/src/main/java/org/cryptomator/cryptofs/fh/ChunkSaver.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/ChunkSaver.java
@@ -3,7 +3,7 @@ package org.cryptomator.cryptofs.fh;
 import org.cryptomator.cryptofs.CryptoFileSystemStats;
 import org.cryptomator.cryptolib.api.Cryptor;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 

--- a/src/main/java/org/cryptomator/cryptofs/fh/CurrentOpenFilePath.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/CurrentOpenFilePath.java
@@ -1,6 +1,6 @@
 package org.cryptomator.cryptofs.fh;
 
-import javax.inject.Qualifier;
+import jakarta.inject.Qualifier;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 

--- a/src/main/java/org/cryptomator/cryptofs/fh/ExceptionsDuringWrite.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/ExceptionsDuringWrite.java
@@ -2,7 +2,7 @@ package org.cryptomator.cryptofs.fh;
 
 import org.cryptomator.cryptofs.ch.CleartextFileChannel;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 
 /**

--- a/src/main/java/org/cryptomator/cryptofs/fh/FileHeaderHolder.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/FileHeaderHolder.java
@@ -8,7 +8,7 @@ import org.cryptomator.cryptolib.api.FileHeader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;

--- a/src/main/java/org/cryptomator/cryptofs/fh/OpenCryptoFile.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/OpenCryptoFile.java
@@ -6,7 +6,7 @@ import org.cryptomator.cryptolib.api.Cryptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.channels.FileChannel;

--- a/src/main/java/org/cryptomator/cryptofs/fh/OpenCryptoFiles.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/OpenCryptoFiles.java
@@ -11,7 +11,7 @@ package org.cryptomator.cryptofs.fh;
 import org.cryptomator.cryptofs.CryptoFileSystemScoped;
 import org.cryptomator.cryptofs.EffectiveOpenOptions;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.BufferUnderflowException;

--- a/src/main/java/org/cryptomator/cryptofs/fh/OpenFileModifiedDate.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/OpenFileModifiedDate.java
@@ -1,6 +1,6 @@
 package org.cryptomator.cryptofs.fh;
 
-import javax.inject.Qualifier;
+import jakarta.inject.Qualifier;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 

--- a/src/main/java/org/cryptomator/cryptofs/fh/OpenFileScoped.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/OpenFileScoped.java
@@ -1,6 +1,6 @@
 package org.cryptomator.cryptofs.fh;
 
-import javax.inject.Scope;
+import jakarta.inject.Scope;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 

--- a/src/main/java/org/cryptomator/cryptofs/fh/OpenFileSize.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/OpenFileSize.java
@@ -5,7 +5,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 
-import javax.inject.Qualifier;
+import jakarta.inject.Qualifier;
 
 @Qualifier
 @Documented

--- a/src/main/java/org/cryptomator/cryptofs/fh/OriginalOpenFilePath.java
+++ b/src/main/java/org/cryptomator/cryptofs/fh/OriginalOpenFilePath.java
@@ -5,7 +5,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 
-import javax.inject.Qualifier;
+import jakarta.inject.Qualifier;
 
 /**
  * The Path used to create an OpenCryptoFile

--- a/src/main/java/org/cryptomator/cryptofs/migration/Migrators.java
+++ b/src/main/java/org/cryptomator/cryptofs/migration/Migrators.java
@@ -17,7 +17,7 @@ import org.cryptomator.cryptolib.api.InvalidPassphraseException;
 import org.cryptomator.cryptolib.api.UnsupportedVaultFormatException;
 import org.cryptomator.cryptolib.common.MasterkeyFileAccess;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/src/main/java/org/cryptomator/cryptofs/migration/v6/Version6Migrator.java
+++ b/src/main/java/org/cryptomator/cryptofs/migration/v6/Version6Migrator.java
@@ -15,7 +15,7 @@ import org.cryptomator.cryptolib.common.MasterkeyFileAccess;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/src/main/java/org/cryptomator/cryptofs/migration/v7/Version7Migrator.java
+++ b/src/main/java/org/cryptomator/cryptofs/migration/v7/Version7Migrator.java
@@ -20,7 +20,7 @@ import org.cryptomator.cryptolib.common.MasterkeyFileAccess;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;

--- a/src/main/java/org/cryptomator/cryptofs/migration/v8/Version8Migrator.java
+++ b/src/main/java/org/cryptomator/cryptofs/migration/v8/Version8Migrator.java
@@ -17,7 +17,7 @@ import org.cryptomator.cryptolib.common.MasterkeyFileAccess;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;


### PR DESCRIPTION
This PR updates [dagger](https://github.com/google/dagger/releases/tag/dagger-2.55) to version 2.55.

The new dagger version allows the usage of classes from `jakarta.inject` dependency instead of `javax.*`. Unfortunately, internally dagger still uses javax.inject, hence the old dependency cannot be removed.

Apart from the migration for build the property `-Adagger.useBindingGraphFix=ENABLED` is set, because this option will be the default in the future anyway.
