### PR TITLE
Fix DecryptFileName feature

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/CiphertextPathValidations.java
+++ b/src/main/java/org/cryptomator/cryptofs/CiphertextPathValidations.java
@@ -1,0 +1,21 @@
+package org.cryptomator.cryptofs;
+
+import com.google.common.io.BaseEncoding;
+
+import java.nio.file.Path;
+
+public class CiphertextPathValidations {
+
+
+	private CiphertextPathValidations() {}
+
+	public static boolean isCiphertextContentDir(Path p) {
+		var twoCharDir = p.getParent();
+		if (twoCharDir == null) {
+			return false;
+		}
+		var testString = twoCharDir.getFileName().toString() + p.getFileName().toString();
+		return testString.length() == 32 && BaseEncoding.base32().canDecode(testString);
+	}
+
+}

--- a/src/main/java/org/cryptomator/cryptofs/DirectoryIdBackup.java
+++ b/src/main/java/org/cryptomator/cryptofs/DirectoryIdBackup.java
@@ -1,12 +1,12 @@
 package org.cryptomator.cryptofs;
 
+import jakarta.inject.Inject;
 import org.cryptomator.cryptofs.common.Constants;
 import org.cryptomator.cryptolib.api.CryptoException;
 import org.cryptomator.cryptolib.api.Cryptor;
 import org.cryptomator.cryptolib.common.DecryptingReadableByteChannel;
 import org.cryptomator.cryptolib.common.EncryptingWritableByteChannel;
 
-import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
@@ -65,6 +65,9 @@ public class DirectoryIdBackup {
 	 * @throws IllegalStateException if the directory id exceeds {@value Constants#MAX_DIR_ID_LENGTH} chars
 	 */
 	public byte[] read(Path ciphertextContentDir) throws IOException, CryptoException, IllegalStateException {
+		if (!CiphertextPathValidations.isCiphertextContentDir(ciphertextContentDir)) {
+			throw new IllegalArgumentException("Directory %s is not a ciphertext content dir".formatted(ciphertextContentDir));
+		}
 		var dirIdBackupFile = getBackupFilePath(ciphertextContentDir);
 		var dirIdBuffer = ByteBuffer.allocate(Constants.MAX_DIR_ID_LENGTH + 1); //a dir id contains at most 36 ascii chars, we add for security checks one more
 

--- a/src/main/java/org/cryptomator/cryptofs/FileNameDecryptor.java
+++ b/src/main/java/org/cryptomator/cryptofs/FileNameDecryptor.java
@@ -43,7 +43,7 @@ class FileNameDecryptor {
 	String decryptFilenameInternal(Path ciphertextNode) throws IOException, UnsupportedOperationException {
 		byte[] dirId = null;
 		try {
-			dirId = dirIdBackup.read(ciphertextNode);
+			dirId = dirIdBackup.read(ciphertextNode.getParent());
 		} catch (NoSuchFileException e) {
 			throw new UnsupportedOperationException("Directory does not have a " + Constants.DIR_ID_BACKUP_FILE_NAME + " file.");
 		} catch (CryptoException | IllegalStateException e) {

--- a/src/test/java/org/cryptomator/cryptofs/DirectoryIdBackupTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/DirectoryIdBackupTest.java
@@ -98,6 +98,13 @@ public class DirectoryIdBackupTest {
 		}
 
 		@Test
+		@DisplayName("If the given path is not a cipherContentDir, throw IllegalArgumentException")
+		public void wrongPath() throws IOException {
+			var dirIdBackupSpy = spy(dirIdBackup);
+			Assertions.assertThrows(IllegalArgumentException.class, () -> dirIdBackupSpy.read(testDir));
+		}
+
+		@Test
 		@DisplayName("If the directory id is longer than 36 characters, throw IllegalStateException")
 		public void contentLongerThan36Chars() throws IOException {
 			var dirIdBackupSpy = spy(dirIdBackup);

--- a/src/test/java/org/cryptomator/cryptofs/FileNameDecryptorTest.java
+++ b/src/test/java/org/cryptomator/cryptofs/FileNameDecryptorTest.java
@@ -54,7 +54,7 @@ public class FileNameDecryptorTest {
 		var ciphertextNode = tmpPath.resolve(ciphertextNodeNameName + fileExtension);
 		var dirId = new byte[]{'f', 'o', 'o', 'b', 'a', 'r'};
 		var expectedClearName = "veryClearText";
-		when(dirIdBackup.read(ciphertextNode)).thenReturn(dirId);
+		when(dirIdBackup.read(tmpPath)).thenReturn(dirId);
 		when(longFileNameProvider.inflate(ciphertextNode)).thenReturn(ciphertextNodeNameName);
 		when(fileNameCryptor.decryptFilename(any(), eq(ciphertextNodeNameName), eq(dirId))).thenReturn(expectedClearName);
 
@@ -78,7 +78,7 @@ public class FileNameDecryptorTest {
 	@DisplayName("If the dirId backup file does not exists, throw UnsupportedOperationException")
 	public void notExistingDirIdFile() throws IOException {
 		var ciphertextNode = tmpPath.resolve("toDecrypt.c9r");
-		when(dirIdBackup.read(ciphertextNode)).thenThrow(NoSuchFileException.class);
+		when(dirIdBackup.read(tmpPath)).thenThrow(NoSuchFileException.class);
 
 		Assertions.assertThrows(UnsupportedOperationException.class, () -> testObjSpy.decryptFilenameInternal(ciphertextNode));
 	}
@@ -87,7 +87,7 @@ public class FileNameDecryptorTest {
 	@DisplayName("If the dirId cannot be read, throw FileSystemException")
 	public void notReadableDirIdFile() throws IOException {
 		var ciphertextNode = tmpPath.resolve("toDecrypt.c9r");
-		when(dirIdBackup.read(ciphertextNode)) //
+		when(dirIdBackup.read(tmpPath)) //
 				.thenThrow(TestCryptoException.class) //
 				.thenThrow(IllegalStateException.class);
 		Assertions.assertThrows(FileSystemException.class, () -> testObjSpy.decryptFilenameInternal(ciphertextNode));
@@ -101,7 +101,7 @@ public class FileNameDecryptorTest {
 		var ciphertextNode = tmpPath.resolve(name + ".c9s");
 		var dirId = new byte[]{'f', 'o', 'o', 'b', 'a', 'r'};
 		var expectedException = new IOException("Inflation failed");
-		when(dirIdBackup.read(ciphertextNode)).thenReturn(dirId);
+		when(dirIdBackup.read(tmpPath)).thenReturn(dirId);
 		when(longFileNameProvider.inflate(ciphertextNode)).thenThrow(expectedException);
 
 		var actual = Assertions.assertThrows(IOException.class, () -> testObjSpy.decryptFilenameInternal(ciphertextNode));
@@ -114,7 +114,7 @@ public class FileNameDecryptorTest {
 		var name = "toDecrypt";
 		var ciphertextNode = tmpPath.resolve(name + ".c9r");
 		var dirId = new byte[]{'f', 'o', 'o', 'b', 'a', 'r'};
-		when(dirIdBackup.read(ciphertextNode)).thenReturn(dirId);
+		when(dirIdBackup.read(tmpPath)).thenReturn(dirId);
 		when(fileNameCryptor.decryptFilename(any(), eq(name), eq(dirId))).thenThrow(TestCryptoException.class);
 
 		Assertions.assertThrows(FileSystemException.class, () -> testObjSpy.decryptFilenameInternal(ciphertextNode));


### PR DESCRIPTION
This PR fixes #289.

Additionally, it adds a path validation in the `DirectoryIdBackup#read` method. Since the path validation might be reused in the future, it is moved to its own class.