### PR TITLE
Feature: Add timestamp to file system events

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/event/BrokenDirFileEvent.java
+++ b/src/main/java/org/cryptomator/cryptofs/event/BrokenDirFileEvent.java
@@ -1,12 +1,22 @@
 package org.cryptomator.cryptofs.event;
 
 import java.nio.file.Path;
+import java.time.Instant;
 
 /**
  * Emitted, if a dir.c9r file is empty or exceeds 1000 Bytes.
  *
+ * @param timestamp timestamp of event appearance
  * @param ciphertextPath path to the broken dir.c9r file
  */
-public record BrokenDirFileEvent(Path ciphertextPath) implements FilesystemEvent {
+public record BrokenDirFileEvent(Instant timestamp, Path ciphertextPath) implements FilesystemEvent {
 
+	public BrokenDirFileEvent(Path ciphertextPath) {
+		this(Instant.now(), ciphertextPath);
+	}
+
+	@Override
+	public Instant getTimestamp() {
+		return timestamp;
+	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/event/BrokenFileNodeEvent.java
+++ b/src/main/java/org/cryptomator/cryptofs/event/BrokenFileNodeEvent.java
@@ -1,15 +1,24 @@
 package org.cryptomator.cryptofs.event;
 
 import java.nio.file.Path;
+import java.time.Instant;
 
 /**
  * Emitted, if a path within the cryptographic filesystem is accessed, but the directory representing it is missing identification files.
  *
+ * @param timestamp timestamp of event appearance
  * @param cleartextPath path within the cryptographic filesystem
  * @param ciphertextPath path of the incomplete, encrypted directory
- *
  * @see org.cryptomator.cryptofs.health.type.UnknownType
  */
-public record BrokenFileNodeEvent(Path cleartextPath, Path ciphertextPath) implements FilesystemEvent {
+public record BrokenFileNodeEvent(Instant timestamp, Path cleartextPath, Path ciphertextPath) implements FilesystemEvent {
 
+	public BrokenFileNodeEvent(Path cleartextPath, Path ciphertextPath) {
+		this(Instant.now(), cleartextPath, ciphertextPath);
+	}
+
+	@Override
+	public Instant getTimestamp() {
+		return timestamp;
+	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/event/ConflictResolutionFailedEvent.java
+++ b/src/main/java/org/cryptomator/cryptofs/event/ConflictResolutionFailedEvent.java
@@ -1,14 +1,24 @@
 package org.cryptomator.cryptofs.event;
 
 import java.nio.file.Path;
+import java.time.Instant;
 
 /**
  * Emitted, if the conflict resolution inside an encrypted directory failed
  *
+ * @param timestamp timestamp of event appearance
  * @param canonicalCleartextPath path of the canonical file within the cryptographic filesystem
  * @param conflictingCiphertextPath path of the encrypted, conflicting file
  * @param reason exception, why the resolution failed
  */
-public record ConflictResolutionFailedEvent(Path canonicalCleartextPath, Path conflictingCiphertextPath, Exception reason) implements FilesystemEvent {
+public record ConflictResolutionFailedEvent(Instant timestamp, Path canonicalCleartextPath, Path conflictingCiphertextPath, Exception reason) implements FilesystemEvent {
 
+	public ConflictResolutionFailedEvent(Path canonicalCleartextPath, Path conflictingCiphertextPath, Exception reason) {
+		this(Instant.now(), canonicalCleartextPath, conflictingCiphertextPath, reason);
+	}
+
+	@Override
+	public Instant getTimestamp() {
+		return timestamp;
+	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/event/ConflictResolvedEvent.java
+++ b/src/main/java/org/cryptomator/cryptofs/event/ConflictResolvedEvent.java
@@ -1,6 +1,7 @@
 package org.cryptomator.cryptofs.event;
 
 import java.nio.file.Path;
+import java.time.Instant;
 
 /**
  * Emitted, if a conflict inside an encrypted directory was resolved.
@@ -10,11 +11,20 @@ import java.nio.file.Path;
  * The file <i>with the suffix</i> is called <b>conflicting</b>
  * On successful conflict resolution the conflicting file is renamed to the <b>resolved</b> file
  *
+ * @param timestamp timestamp of event appearance
  * @param canonicalCleartextPath path of the canonical file within the cryptographic filesystem
  * @param conflictingCiphertextPath path of the encrypted, conflicting file
  * @param resolvedCleartextPath path of the resolved file within the cryptographic filesystem
  * @param resolvedCiphertextPath path of the resolved, encrypted file
  */
-public record ConflictResolvedEvent(Path canonicalCleartextPath, Path conflictingCiphertextPath, Path resolvedCleartextPath, Path resolvedCiphertextPath) implements FilesystemEvent {
+public record ConflictResolvedEvent(Instant timestamp, Path canonicalCleartextPath, Path conflictingCiphertextPath, Path resolvedCleartextPath, Path resolvedCiphertextPath) implements FilesystemEvent {
 
+	public ConflictResolvedEvent(Path canonicalCleartextPath, Path conflictingCiphertextPath, Path resolvedCleartextPath, Path resolvedCiphertextPath) {
+		this(Instant.now(), canonicalCleartextPath, conflictingCiphertextPath, resolvedCleartextPath, resolvedCiphertextPath);
+	}
+
+	@Override
+	public Instant getTimestamp() {
+		return timestamp;
+	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/event/DecryptionFailedEvent.java
+++ b/src/main/java/org/cryptomator/cryptofs/event/DecryptionFailedEvent.java
@@ -1,12 +1,23 @@
 package org.cryptomator.cryptofs.event;
 
 import java.nio.file.Path;
+import java.time.Instant;
 
 /**
  * Emitted, if a decryption operation fails.
  *
+ * @param timestamp timestamp of event appearance
  * @param ciphertextPath path to the encrypted resource
  * @param e thrown exception
  */
-public record DecryptionFailedEvent(Path ciphertextPath, Exception e) implements FilesystemEvent {
+public record DecryptionFailedEvent(Instant timestamp, Path ciphertextPath, Exception e) implements FilesystemEvent {
+
+	public DecryptionFailedEvent(Path ciphertextPath, Exception e) {
+		this(Instant.now(), ciphertextPath, e);
+	}
+
+	@Override
+	public Instant getTimestamp() {
+		return timestamp;
+	}
 }

--- a/src/main/java/org/cryptomator/cryptofs/event/FilesystemEvent.java
+++ b/src/main/java/org/cryptomator/cryptofs/event/FilesystemEvent.java
@@ -1,5 +1,6 @@
 package org.cryptomator.cryptofs.event;
 
+import java.time.Instant;
 import java.util.function.Consumer;
 
 /**
@@ -11,12 +12,12 @@ import java.util.function.Consumer;
  * {@code
  * FilesystemEvent fse;
  * switch (fse) {
- *   case DecryptionFailedEvent e -> //do stuff
- *   case ConflictResolvedEvent e -> //do other stuff
- *   //other cases
+ * case DecryptionFailedEvent e -> //do stuff
+ * case ConflictResolvedEvent e -> //do other stuff
+ * //other cases
  * }
  * if( fse instanceof DecryptionFailedEvent dfe) {
- *   //do more stuff
+ * //do more stuff
  * }
  * }.
  *
@@ -24,4 +25,10 @@ import java.util.function.Consumer;
  */
 public sealed interface FilesystemEvent permits BrokenDirFileEvent, BrokenFileNodeEvent, ConflictResolutionFailedEvent, ConflictResolvedEvent, DecryptionFailedEvent {
 
+	/**
+	 * Gets the timestamp when the event occurred.
+	 *
+	 * @return the event timestamp as an {@link Instant}
+	 */
+	Instant getTimestamp();
 }

--- a/src/main/java/org/cryptomator/cryptofs/event/FilesystemEvent.java
+++ b/src/main/java/org/cryptomator/cryptofs/event/FilesystemEvent.java
@@ -12,12 +12,12 @@ import java.util.function.Consumer;
  * {@code
  * FilesystemEvent fse;
  * switch (fse) {
- * case DecryptionFailedEvent e -> //do stuff
- * case ConflictResolvedEvent e -> //do other stuff
- * //other cases
+ *   case ConflictResolvedEvent e -> //do other stuff
+ *   case DecryptionFailedEvent(Instant timestamp, Path ciphertext, Exception ex)  -> //do stuff
+ *   //... other cases
  * }
- * if( fse instanceof DecryptionFailedEvent dfe) {
- * //do more stuff
+ * if( fse instanceof DecryptionFailedEvent(Instant timestamp, Path ciphertext, Exception ex) {
+ *   //do more stuff
  * }
  * }.
  *


### PR DESCRIPTION
Relates to #277 

This PR extends the `FilesystemEvent` interface by a `getTimestamp` method and adds a timestamp field to every subclass of `FilesystemEvent`