### PR TITLE
Fix: Remove CryptoPaths from API

### DIFF
--- a/src/main/java/org/cryptomator/cryptofs/event/BrokenFileNodeEvent.java
+++ b/src/main/java/org/cryptomator/cryptofs/event/BrokenFileNodeEvent.java
@@ -7,14 +7,14 @@ import java.time.Instant;
  * Emitted, if a path within the cryptographic filesystem is accessed, but the directory representing it is missing identification files.
  *
  * @param timestamp timestamp of event appearance
- * @param cleartextPath path within the cryptographic filesystem
+ * @param cleartextPath path (string) within the cryptographic filesystem
  * @param ciphertextPath path of the incomplete, encrypted directory
  * @see org.cryptomator.cryptofs.health.type.UnknownType
  */
-public record BrokenFileNodeEvent(Instant timestamp, Path cleartextPath, Path ciphertextPath) implements FilesystemEvent {
+public record BrokenFileNodeEvent(Instant timestamp, String cleartextPath, Path ciphertextPath) implements FilesystemEvent {
 
 	public BrokenFileNodeEvent(Path cleartextPath, Path ciphertextPath) {
-		this(Instant.now(), cleartextPath, ciphertextPath);
+		this(Instant.now(), cleartextPath.toString(), ciphertextPath);
 	}
 
 	@Override

--- a/src/main/java/org/cryptomator/cryptofs/event/ConflictResolutionFailedEvent.java
+++ b/src/main/java/org/cryptomator/cryptofs/event/ConflictResolutionFailedEvent.java
@@ -7,14 +7,14 @@ import java.time.Instant;
  * Emitted, if the conflict resolution inside an encrypted directory failed
  *
  * @param timestamp timestamp of event appearance
- * @param canonicalCleartextPath path of the canonical file within the cryptographic filesystem
+ * @param canonicalCleartextPath path (string) of the canonical file within the cryptographic filesystem
  * @param conflictingCiphertextPath path of the encrypted, conflicting file
  * @param reason exception, why the resolution failed
  */
-public record ConflictResolutionFailedEvent(Instant timestamp, Path canonicalCleartextPath, Path conflictingCiphertextPath, Exception reason) implements FilesystemEvent {
+public record ConflictResolutionFailedEvent(Instant timestamp, String canonicalCleartextPath, Path conflictingCiphertextPath, Exception reason) implements FilesystemEvent {
 
 	public ConflictResolutionFailedEvent(Path canonicalCleartextPath, Path conflictingCiphertextPath, Exception reason) {
-		this(Instant.now(), canonicalCleartextPath, conflictingCiphertextPath, reason);
+		this(Instant.now(), canonicalCleartextPath.toString(), conflictingCiphertextPath, reason);
 	}
 
 	@Override

--- a/src/main/java/org/cryptomator/cryptofs/event/ConflictResolvedEvent.java
+++ b/src/main/java/org/cryptomator/cryptofs/event/ConflictResolvedEvent.java
@@ -12,15 +12,15 @@ import java.time.Instant;
  * On successful conflict resolution the conflicting file is renamed to the <b>resolved</b> file
  *
  * @param timestamp timestamp of event appearance
- * @param canonicalCleartextPath path of the canonical file within the cryptographic filesystem
+ * @param canonicalCleartextPath path (string) of the canonical file within the cryptographic filesystem
  * @param conflictingCiphertextPath path of the encrypted, conflicting file
- * @param resolvedCleartextPath path of the resolved file within the cryptographic filesystem
+ * @param resolvedCleartextPath path (string) of the resolved file within the cryptographic filesystem
  * @param resolvedCiphertextPath path of the resolved, encrypted file
  */
-public record ConflictResolvedEvent(Instant timestamp, Path canonicalCleartextPath, Path conflictingCiphertextPath, Path resolvedCleartextPath, Path resolvedCiphertextPath) implements FilesystemEvent {
+public record ConflictResolvedEvent(Instant timestamp, String canonicalCleartextPath, Path conflictingCiphertextPath, String resolvedCleartextPath, Path resolvedCiphertextPath) implements FilesystemEvent {
 
 	public ConflictResolvedEvent(Path canonicalCleartextPath, Path conflictingCiphertextPath, Path resolvedCleartextPath, Path resolvedCiphertextPath) {
-		this(Instant.now(), canonicalCleartextPath, conflictingCiphertextPath, resolvedCleartextPath, resolvedCiphertextPath);
+		this(Instant.now(), canonicalCleartextPath.toString(), conflictingCiphertextPath, resolvedCleartextPath.toString(), resolvedCiphertextPath);
 	}
 
 	@Override


### PR DESCRIPTION
This only effects classes in the event package.

Some events contained CryptoPaths, which cannot be accessed anymore if the actual filesystem is closed. This can lead to unforseen errors in consumer libraries, which expect the path objects can still be "used".

This is a **breaking change**.